### PR TITLE
Add verification tests (tests that are run against stainless)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,7 @@ dependencies = [
  "env_logger",
  "serde_json",
  "stainless",
+ "stainless_backend",
  "stainless_data",
  "stainless_extraction",
  "tempfile",

--- a/stainless_backend/src/lib.rs
+++ b/stainless_backend/src/lib.rs
@@ -17,6 +17,7 @@ pub struct Config {
   print_types: bool,
   debug_trees: bool,
   debug_phases: Vec<String>,
+  strict_arithmetic: bool,
 }
 
 impl Default for Config {
@@ -27,6 +28,7 @@ impl Default for Config {
       print_types: false,
       debug_trees: false,
       debug_phases: vec![],
+      strict_arithmetic: false,
     }
   }
 }
@@ -55,7 +57,8 @@ impl Backend {
       .arg("--vc-cache=false")
       .arg(format!("--timeout={}", config.timeout))
       .arg(format!("--print-ids={}", config.print_ids))
-      .arg(format!("--print-types={}", config.print_types));
+      .arg(format!("--print-types={}", config.print_types))
+      .arg(format!("--strict-arithmetic={}", config.strict_arithmetic));
     if config.debug_trees {
       cmd
         .arg("--debug=trees")
@@ -101,7 +104,7 @@ impl Backend {
       .map_err(|err| format!("Failed to parse response: {}", err))
   }
 
-  pub fn query_for_program(&mut self, symbols: st::Symbols<'_>) -> Result<Response, String> {
+  pub fn query_for_program(&mut self, symbols: &st::Symbols) -> Result<Response, String> {
     use stainless_data::ser::*;
     use tempfile::NamedTempFile;
 

--- a/stainless_backend/tests/stainless_run_tests.rs
+++ b/stainless_backend/tests/stainless_run_tests.rs
@@ -19,19 +19,19 @@ fn reponse_has_no_errors(response: Response) -> bool {
 #[test]
 fn test_one_query() {
   let f = Factory::new();
-  let mut backend = Backend::create(Config::default()).unwrap();
   let symbols = examples::identity_symbols(&f);
-  let response = backend.query_for_program(symbols).unwrap();
+  let mut backend = Backend::create(Config::default()).unwrap();
+  let response = backend.query_for_program(&symbols).unwrap();
   assert!(reponse_has_no_errors(response));
 }
 
 #[test]
 fn test_many_queries() {
   let f = Factory::new();
+  let symbols = examples::identity_symbols(&f);
   let mut backend = Backend::create(Config::default()).unwrap();
   for _ in 0..5 {
-    let symbols = examples::identity_symbols(&f);
-    let response = backend.query_for_program(symbols).unwrap();
+    let response = backend.query_for_program(&symbols).unwrap();
     assert!(reponse_has_no_errors(response));
   }
 }

--- a/stainless_frontend/Cargo.toml
+++ b/stainless_frontend/Cargo.toml
@@ -8,18 +8,17 @@ categories = ["development-tools"]
 
 [[bin]]
 name = "rustc_to_stainless"
-test = false
 doctest = false
 
 [[bin]]
 name = "cargo-stainless"
-test = false
 doctest = false
 
 [lib]
 doctest = false
 
 [dependencies]
+stainless_backend = { path = "../stainless_backend" }
 stainless_data = { path = "../stainless_data" }
 stainless_extraction = { path = "../stainless_extraction" }
 clap = "2.33.1"

--- a/stainless_frontend/tests/fail/switch_int.rs
+++ b/stainless_frontend/tests/fail/switch_int.rs
@@ -1,0 +1,27 @@
+extern crate stainless;
+
+fn switch_int(r: &mut i32, v: i32) {
+  *r = v;
+}
+
+fn main() {
+  let mut x = 1;
+  println!("x = {}", x);
+  switch_int(&mut x, 2);
+  println!("x = {}", x);
+}
+
+/*
+
+def switch_int(r: i32, v: i32) {
+  r = v;
+}
+
+def main() {
+  var x = 1;
+  println!("x = {}", x);
+  switch_int(x, 2);
+  println!("x = {}", x);
+}
+
+*/

--- a/stainless_frontend/tests/fail/switch_ref.rs
+++ b/stainless_frontend/tests/fail/switch_ref.rs
@@ -1,0 +1,31 @@
+extern crate stainless;
+
+fn switch_ref<'a>(rr: &mut &'a i32, v: &'a i32) {
+  *rr = v;
+}
+
+fn main() {
+  let a = 1;
+  let b = 2;
+  let mut r = &a;
+  println!("*r = {}", *r);
+  switch_ref(&mut r, &b);
+  println!("*r = {}", *r);
+}
+
+/*
+
+def switch_ref(rr: i32, v: i32) {
+  rr = v;
+}
+
+def main() {
+  val a = 1;
+  val b = 2;
+  var r = a;
+  println!("*r = {}", r);   // 1
+  switch_ref(r, b);         // No side-effect !!!
+  println!("*r = {}", r);   // 1              !!!
+}
+
+*/

--- a/stainless_frontend/tests/pass/blocks.rs
+++ b/stainless_frontend/tests/pass/blocks.rs
@@ -2,7 +2,7 @@ fn foo(_n: i32) -> () {}
 
 pub fn bar(x: i32) -> i32 {
   foo(x);
-  let y = x * 2;
+  let y = x / 2;
   foo(y);
   if y <= 0 {
     1

--- a/stainless_frontend/tests/pass/fact.rs
+++ b/stainless_frontend/tests/pass/fact.rs
@@ -1,7 +1,7 @@
 extern crate stainless;
 use stainless::*;
 
-#[pre(x >= 0)]
+#[pre(x >= 0 && x < 10)]
 #[post(ret >= 0)]
 pub fn fact(x: i32) -> i32 {
   if x <= 0 {

--- a/stainless_frontend/tests/pass/tuples.rs
+++ b/stainless_frontend/tests/pass/tuples.rs
@@ -1,3 +1,8 @@
+extern crate stainless;
+use stainless::*;
+
+#[pre(x > -2147483648)]
+#[post(ret >= 0)]
 pub fn abs(x: i32) -> i32 {
   if x >= 0 {
     x
@@ -6,6 +11,7 @@ pub fn abs(x: i32) -> i32 {
   }
 }
 
+#[pre(x > -2147483648)]
 pub fn abs_pair(x: i32) -> (i32, i32) {
   (x, abs(x))
 }


### PR DESCRIPTION
More tests can be added in `stainless_frontend/tests/{fail,pass}/`. To be picked up by `cargo test`, files must be registered at the bottom of `stainless_frontend/tests/extraction_tests.rs`. To run `cargo test` with verification tests, make sure that `STAINLESS_HOME` is set to the path of the standalone `stainless-noxt` directory.