### PR TITLE
Enable verification through cargo-stainless

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This repository contains an experimental Rust frontend for the Stainless verifie
 
 Our frontend is implemented as an alternative driver for rustc, which means that we run the standard Rust compiler and intercept its high-level IR after type-checking.
 For a given compilation unit we produce a set of Stainless `ClassDef`s and `FunDef`s, and serialize them to a file which can then be verified independently using a new Stainless interface called `stainless-noxt` -- a "no-extraction" mode which merely deserializes the program representation from the previously generated file.
-A Rust-version of Stainless data structures and associated serialization code is located in the `stainless_data` crate.
-The actual code interfacing with rustc and performing program extraction is found in the `stainless_driver` crate.
+A Rust version of Stainless data structures and associated serialization code is located in the `stainless_data` crate.
+The actual code interfacing with rustc and performing program extraction is found in the `stainless_extraction` and `stainless_frontend` crates.
 
 ## Installation
 
@@ -15,23 +15,18 @@ The following instructions assume that you have installed Rust using [rustup](ht
 - Clone this repo in `/basedir/rust-stainless`.
 - Make sure your `rustup` toolchain within that directory is set to the currently supported nightly version (via `rustup override set $(cat rust-toolchain)` in `/basedir/rust-stainless`).
 - Make sure you have the `rustc-dev` and `llvm-tools-preview` components installed (via `rustup component add rustc-dev llvm-tools-preview`).
-- Install `stainless_driver` (via `cargo install --path stainless_driver/`). This will build the `rustc_to_stainless` driver, which is essentially a modified version of `rustc`, and `cargo-stainless`, which provides a convenient way for invoking `rustc_to_stainless` from within Cargo project folders. Installation ensures that both of these binaries end up on your `PATH`.
-- Clone and `sbt publishLocal` [inox with the modified serializer](https://github.com/epfl-lara/inox/tree/rust-interop) in `/basedir/inox`.
-- Clone and build [stainless with the `stainless-noxt` frontend](https://github.com/epfl-lara/stainless/tree/rust-interop) in `/basedir/stainless` to verify the extracted programs.
+- Install `stainless_driver` (via `cargo install --path stainless_frontend/`). This will build the `rustc_to_stainless` driver, which is essentially a modified version of `rustc`, and `cargo-stainless`, which provides a convenient way of invoking `rustc_to_stainless` from within Cargo project folders. Installation ensures that both of these binaries end up on your `PATH`.
+- Get a copy of the standalone version of `stainless-noxt` for [Linux](lara.epfl.ch/~gschmid/stainless/stainless-noxt-SNAPSHOT-linux.zip) or [macOS](lara.epfl.ch/~gschmid/stainless/stainless-noxt-SNAPSHOT-mac.zip). (This is based on forks of [inox](https://github.com/epfl-lara/inox/tree/rust-interop) and [stainless]((https://github.com/epfl-lara/stainless/tree/rust-interop)).) Extract it to `/basedir/stainless`.
+- Make sure that your `STAINLESS_HOME` environmental variable points to `/basedir/stainless`.
+Now you should be good to go.
 
 ## Usage
 
 Assuming you have followed the above installation instructions, using `rustc_to_stainless` in basic Cargo projects is easy:
 Navigate to a project folder (i.e., a folder containing a `Cargo.toml` file), run `cargo build`, and, consequently, `cargo stainless`.
 This will invoke `rustc_to_stainless` for the last build target in your Cargo project with essentially the same configuration as `cargo build` would.
-The frontend will produce some debug output, and, if successful, write the extracted Stainless program to `./output.inoxser`.
+The frontend will produce some debug output, and, if extraction is successful, send the program to stainless for verification.
 Similarly to other cargo commands, you can also use `cargo stainless --example foo` to instead extract a specific example.
-
-You can verify the extracted program using Stainless and the `stainless-noxt` subproject.
-To do so with a checked out version of the Stainless repo, run `sbt` in the root folder of the repo and consequently switch to the appropriate subproject using `project stainless-noxt`.
-The actual verification can be started using `run /the/path/to/output.inoxser`.
-For a slightly more practical setup, you can run Stainless in separate session and start it in watch mode using `run --watch /the/path/to/output.inoxser`.
-This will automatically retrigger verification whenever `output.inoxser` is updated.
 
 ## What to expect
 
@@ -39,6 +34,9 @@ Note that the fragment of Rust currently supported is very limited. *TODO: Give 
 
 ## Development
 
-During development, it is useful to add `stainless_driver/target/debug` to `PATH`, so that `cargo-stainless` always invokes the most recently compiled version of `rustc_to_stainless`.
-To interact directly with `rustc_to_stainless` (and avoid the indirection of Cargo), there exists an auxiliary script at `scripts/rustc_to_stainless` which injects some of the necessary flags.
-The script can be used like the standard rustc binary, e.g., using `scripts/rustc_to_stainless --crate-type=lib examples/fact.rs` to extract the factorial function example.
+You can also verify the extracted programs directly using Stainless and the `stainless-noxt` subproject.
+First, export the serialized stainless program using `cargo stainless --export output.inoxser`.
+To then run verification on that file, navigate to your checked-out Stainless repo, run `sbt` in the root folder of the repo, and consequently switch to the appropriate subproject using `project stainless-noxt`.
+The actual verification can be started using `run /the/path/to/output.inoxser`.
+<!-- For a slightly more practical setup, you can run Stainless in separate session and start it in watch mode using `run --watch /the/path/to/output.inoxser`.
+This will automatically retrigger verification whenever `output.inoxser` is updated. --!>

--- a/demo/examples/tuples.rs
+++ b/demo/examples/tuples.rs
@@ -1,5 +1,8 @@
 extern crate stainless;
+use stainless::*;
 
+#[pre(x > -2147483648)]
+#[post(ret >= 0)]
 pub fn abs(x: i32) -> i32 {
   if x >= 0 {
     x
@@ -8,6 +11,7 @@ pub fn abs(x: i32) -> i32 {
   }
 }
 
+#[pre(x > -2147483648)]
 pub fn abs_pair(x: i32) -> (i32, i32) {
   (x, abs(x))
 }
@@ -15,8 +19,5 @@ pub fn abs_pair(x: i32) -> (i32, i32) {
 pub fn swap(t: (i32, i32)) -> (i32, i32) {
   (t.1, t.0)
 }
-
-// pub fn fst((x, _): (i32, i32)) -> i32 { x }  // TODO
-// pub fn snd((_, y): (i32, i32)) -> i32 { y }  // TODO
 
 fn main() -> () {}

--- a/stainless_backend/src/lib.rs
+++ b/stainless_backend/src/lib.rs
@@ -9,7 +9,7 @@ use std::result::Result;
 use stainless_data::ast as st;
 
 pub mod messages;
-use messages::Response;
+use messages::{Report, Response};
 
 pub struct Config {
   timeout: usize,
@@ -128,4 +128,13 @@ fn find_stainless_home() -> Result<PathBuf, String> {
       Err("Could not find stainless directory. Please make sure STAINLESS_HOME is set.".into())
     }
   }
+}
+
+/// Convenience method to verify a single program
+pub fn verify_program(config: Config, symbols: &st::Symbols) -> Result<Report, String> {
+  let mut backend = Backend::create(config)?;
+  let response = backend.query_for_program(symbols)?;
+  response
+    .into_verification_report()
+    .ok_or_else(|| "No verification report found".into())
 }

--- a/stainless_backend/src/messages.rs
+++ b/stainless_backend/src/messages.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use std::fmt;
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "status")]
@@ -54,6 +55,17 @@ impl VerificationStatus {
     match self {
       VerificationStatus::Valid {} | VerificationStatus::ValidFromCache {} => true,
       _ => false,
+    }
+  }
+}
+
+impl fmt::Display for VerificationStatus {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      VerificationStatus::Valid {} => write!(f, "Valid"),
+      VerificationStatus::ValidFromCache {} => write!(f, "Valid from cache"),
+      VerificationStatus::Inconclusive {} => write!(f, "Unknown"),
+      VerificationStatus::Invalid {} => write!(f, "Invalid"),
     }
   }
 }

--- a/stainless_backend/tests/stainless_run_tests.rs
+++ b/stainless_backend/tests/stainless_run_tests.rs
@@ -2,17 +2,14 @@ extern crate stainless_backend;
 
 use stainless_data::ast::Factory;
 
-use stainless_backend::messages::{Report, Response};
-use stainless_backend::{Backend, Config};
+use stainless_backend::messages::Report;
+use stainless_backend::{verify_program, Backend, Config};
 
 pub mod examples;
 
-fn reponse_has_no_errors(response: Response) -> bool {
-  match response.into_verification_report() {
-    Some(Report::Verification { results, .. }) => {
-      results.iter().all(|result| result.status.is_valid())
-    }
-    None => false,
+fn reponse_has_no_errors(report: Report) -> bool {
+  match report {
+    Report::Verification { results, .. } => results.iter().all(|result| result.status.is_valid()),
   }
 }
 
@@ -20,9 +17,8 @@ fn reponse_has_no_errors(response: Response) -> bool {
 fn test_one_query() {
   let f = Factory::new();
   let symbols = examples::identity_symbols(&f);
-  let mut backend = Backend::create(Config::default()).unwrap();
-  let response = backend.query_for_program(&symbols).unwrap();
-  assert!(reponse_has_no_errors(response));
+  let report = verify_program(Config::default(), &symbols).unwrap();
+  assert!(reponse_has_no_errors(report));
 }
 
 #[test]
@@ -32,6 +28,10 @@ fn test_many_queries() {
   let mut backend = Backend::create(Config::default()).unwrap();
   for _ in 0..5 {
     let response = backend.query_for_program(&symbols).unwrap();
-    assert!(reponse_has_no_errors(response));
+    if let Some(report) = response.into_verification_report() {
+      assert!(reponse_has_no_errors(report));
+    } else {
+      assert!(false);
+    }
   }
 }

--- a/stainless_extraction/src/lib.rs
+++ b/stainless_extraction/src/lib.rs
@@ -63,6 +63,7 @@ pub fn extract_crate<'l, 'tcx: 'l>(
     eprintln!(" - Fun {}", fd.id);
     // eprintln!(" > {:#?}", fd);
   }
+  eprintln!();
 
   st::Symbols::new(adts, functions)
 }

--- a/stainless_frontend/src/bin/rustc_to_stainless.rs
+++ b/stainless_frontend/src/bin/rustc_to_stainless.rs
@@ -1,8 +1,17 @@
 #![feature(rustc_private)]
+extern crate rustc_middle;
 extern crate rustc_session;
 
+use std::env;
+use std::path::PathBuf;
+
+use rustc_middle::ty::TyCtxt;
 use rustc_session::config::ErrorOutputType;
 use rustc_session::early_error;
+
+use stainless_backend::messages::*;
+use stainless_backend::{verify_program, Config};
+use stainless_data::ast as st;
 
 fn main() -> Result<(), ()> {
   let args = std::env::args_os()
@@ -19,7 +28,80 @@ fn main() -> Result<(), ()> {
 
   stainless_frontend::run(args, |tcx, symbols| {
     tcx.sess.abort_if_errors();
-    let output_path = std::path::Path::new("./output.inoxser");
-    stainless_frontend::output_program(output_path, symbols);
+    match env::var("RUSTSTAINLESS_EXPORT").ok() {
+      Some(export_path) => {
+        tcx
+          .sess
+          .note_without_error(format!("Exporting extracted program to {}.", export_path).as_str());
+        let output_path = PathBuf::from(export_path);
+        output_program(output_path, symbols);
+      }
+      None => verify_program_and_report(tcx, symbols),
+    }
   })
+}
+
+fn output_program<P: AsRef<std::path::Path>>(path: P, symbols: st::Symbols) {
+  use stainless_data::ser::{BufferSerializer, Serializable};
+  let mut ser = BufferSerializer::new();
+  symbols
+    .serialize(&mut ser)
+    .expect("Unable to serialize stainless program");
+  std::fs::write(path, ser.as_slice()).expect("Unable to write serialized stainless program");
+}
+
+fn verify_program_and_report(tcx: TyCtxt, symbols: st::Symbols) {
+  // fn build_id_map<'l>(syms: &st::Symbols<'l>) -> HashMap<usize, &'l st::SymbolIdentifier<'l>> {
+  //   let mut map = HashMap::new();
+  //   for &id in syms.sorts.keys().chain(syms.functions.keys()) {
+  //     map.insert(id.id.globalId as usize, id);
+  //   }
+  //   map
+  // }
+
+  fn print_results<'l>(_tcx: TyCtxt, _symbols: &st::Symbols<'l>, results: Vec<VerificationResult>) {
+    // let id_map = build_id_map(symbols);
+    let data: Vec<Vec<String>> = results
+      .iter()
+      .map(|result| {
+        // let id = id_map[&result.id.gid];
+        // let name = id.symbol_path.join("::");
+        let name = result.id.name.clone();
+        let time = format!("{:.1}", (result.time as f32) / 1000.0);
+        vec![name, result.kind.clone(), time, result.status.to_string()]
+      })
+      .collect();
+
+    for row in data {
+      println!(
+        "- {:<38} {:^32} {:>7} {:>18}",
+        row[0], row[1], row[2], row[3]
+      );
+    }
+    println!();
+  }
+
+  let sess = tcx.sess;
+  match verify_program(Config::default(), &symbols) {
+    Ok(Report::Verification { results, sources }) => {
+      sess.note_without_error(format!("Verified {} items.", sources.len()).as_str());
+      let invalids = results
+        .iter()
+        .filter(|result| !result.status.is_valid())
+        .collect::<Vec<_>>();
+      if invalids.is_empty() {
+        sess.note_without_error("All VCs passed!\n");
+      } else {
+        sess.warn(format!("Failed to prove {} VCs:", invalids.len()).as_str());
+      }
+      print_results(tcx, &symbols, results);
+    }
+    Err(msg) => sess.fatal(
+      format!(
+        "An error occur while trying to verify the extracted program: {}",
+        msg,
+      )
+      .as_str(),
+    ),
+  }
 }

--- a/stainless_frontend/src/lib.rs
+++ b/stainless_frontend/src/lib.rs
@@ -70,12 +70,3 @@ impl<E: FnOnce(TyCtxt<'_>, st::Symbols<'_>) + Send> Callbacks for ExtractionCall
     Compilation::Stop
   }
 }
-
-pub fn output_program<P: AsRef<std::path::Path>>(path: P, symbols: st::Symbols) {
-  use stainless_data::ser::{BufferSerializer, Serializable};
-  let mut ser = BufferSerializer::new();
-  symbols
-    .serialize(&mut ser)
-    .expect("Unable to serialize stainless program");
-  std::fs::write(path, ser.as_slice()).expect("Unable to write serialized stainless program");
-}


### PR DESCRIPTION
 This PR completes the workflow around `cargo stainless`. Previously the tool would only extract a program and write it to a file. Now `cargo stainless` will by default also invoke stainless to perform verification on the resulting program. A small report of the verification results similar to that in Stainless is shown.

The old behavior is still available via `cargo stainless --export output.inoxser`.

This PR also includes some light refactoring of the `stainless_backend` interface and an update on the readme to reflect the changes in usage.