### PR TITLE
Add asserts and various missing operations on integers

### DIFF
--- a/stainless_backend/src/lib.rs
+++ b/stainless_backend/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate serde;
 extern crate serde_json;
 
+use std::env;
 use std::io::{LineWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -63,6 +64,9 @@ impl Backend {
       cmd
         .arg("--debug=trees")
         .arg(format!("--debug-phases={}", config.debug_phases.join(",")));
+    }
+    if let Ok(extra_flags) = env::var("STAINLESS_FLAGS") {
+      cmd.args(extra_flags.split(' '));
     }
 
     let child = cmd

--- a/stainless_extraction/src/std_items.rs
+++ b/stainless_extraction/src/std_items.rs
@@ -1,0 +1,173 @@
+use std::collections::HashMap;
+
+use rustc_hir::def_id::{CrateId, CrateNum, DefId, DefIndex};
+use rustc_hir::lang_items::*;
+use rustc_middle::ty::TyCtxt;
+use rustc_span::symbol::Symbol;
+
+/// A standard item, either a rust LangItem, or one of the stainless library
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub(super) enum StdItem {
+  FnTrait,
+  FnMutTrait,
+  FnOnceTrait,
+  SizedTrait,
+  BeginPanicFn,
+  BeginPanicFmtFn,
+}
+
+use StdItem::*;
+
+const NUM_STD_ITEMS: usize = 6;
+
+impl StdItem {
+  fn index(self) -> usize {
+    match self {
+      FnTrait => 0,
+      FnMutTrait => 1,
+      FnOnceTrait => 2,
+      SizedTrait => 3,
+      BeginPanicFn => 4,
+      BeginPanicFmtFn => 5,
+    }
+  }
+
+  pub fn name(self) -> &'static str {
+    match self {
+      FnTrait => "Fn",
+      FnMutTrait => "FnMut",
+      FnOnceTrait => "FnOnce",
+      SizedTrait => "Sized",
+      BeginPanicFn => "begin_panic",
+      BeginPanicFmtFn => "begin_panic_fmt",
+    }
+  }
+
+  pub fn lang_item(self) -> Option<LangItem> {
+    match self {
+      FnTrait => Some(FnTraitLangItem),
+      FnMutTrait => Some(FnMutTraitLangItem),
+      FnOnceTrait => Some(FnOnceTraitLangItem),
+      SizedTrait => Some(SizedTraitLangItem),
+      BeginPanicFn => Some(BeginPanicFnLangItem),
+      _ => None,
+    }
+  }
+}
+
+impl From<LangItem> for StdItem {
+  fn from(item: LangItem) -> StdItem {
+    match item {
+      FnTraitLangItem => FnTrait,
+      FnMutTraitLangItem => FnMutTrait,
+      FnOnceTraitLangItem => FnOnceTrait,
+      SizedTraitLangItem => SizedTrait,
+      BeginPanicFnLangItem => BeginPanicFn,
+      _ => unimplemented!(),
+    }
+  }
+}
+
+#[derive(Debug)]
+pub(super) struct StdItems {
+  item_to_def: [DefId; NUM_STD_ITEMS],
+  def_to_item: HashMap<DefId, StdItem>,
+}
+
+impl StdItems {
+  pub(super) fn collect(tcx: TyCtxt) -> Self {
+    let dummy_def_id = Self::make_def_id(CrateNum::Index(CrateId::from_usize(0)), 0);
+    let item_to_def = [dummy_def_id; NUM_STD_ITEMS];
+    let def_to_item: HashMap<DefId, StdItem> = HashMap::new();
+
+    let mut this = Self {
+      item_to_def,
+      def_to_item,
+    };
+
+    // Register rust lang items
+    this.register_items_from_lang_items(
+      tcx,
+      &[FnTrait, FnMutTrait, FnOnceTrait, SizedTrait, BeginPanicFn],
+    );
+
+    // Register additional items from the rust standard library
+    let std_crate_num = this.item_to_def(BeginPanicFn).krate;
+    this.register_items_from_crate(tcx, &[BeginPanicFmtFn], std_crate_num);
+
+    // Register items from stainless crate
+    // let stainless_sym = Symbol::intern("stainless");
+    // let stainless_crate_num = match tcx
+    //   .crates()
+    //   .iter()
+    //   .find(|&&cnum| tcx.crate_name(cnum) == stainless_sym)
+    //   .copied()
+    // {
+    //   Some(cnum) => cnum,
+    //   None => tcx.sess.fatal(
+    //     "Couldn't find stainless library. Make sure it is included using 'extern crate stainless;'",
+    //   ),
+    // };
+    // this.register_items_from_crate(tcx, stainless_items, stainless_crate_num);
+
+    this
+  }
+
+  fn make_def_id(cnum: CrateNum, index: usize) -> DefId {
+    DefId {
+      krate: cnum,
+      index: DefIndex::from_usize(index),
+    }
+  }
+
+  fn register_items_from_lang_items(&mut self, tcx: TyCtxt, items: &[StdItem]) {
+    for item in items {
+      let def_id = tcx.require_lang_item(item.lang_item().unwrap(), None);
+      self.item_to_def[item.index()] = def_id;
+      self.def_to_item.insert(def_id, *item);
+    }
+  }
+
+  // HACK(gsps): A horrible way to do this, but rustc -- as far as I can tell -- does not expose
+  // any API for finding a specific item in, or enumerating all items of a crate.
+  fn register_items_from_crate(&mut self, tcx: TyCtxt, items: &[StdItem], cnum: CrateNum) {
+    let mut items: HashMap<Symbol, StdItem> = items
+      .iter()
+      .map(|item| (Symbol::intern(item.name()), *item))
+      .collect();
+
+    for index in 0.. {
+      if items.is_empty() {
+        break; // We found DefIds for all items, we're done.
+      }
+      let def_id = Self::make_def_id(cnum, index);
+      if let Some(ref name_sym) = tcx
+        .def_path(def_id)
+        .data
+        .last()
+        .map(|data| data.data.as_symbol())
+      {
+        if let Some(item) = items.remove(name_sym) {
+          self.item_to_def[item.index()] = def_id;
+          self.def_to_item.insert(def_id, item);
+        }
+      }
+    }
+  }
+
+  #[inline]
+  pub(super) fn item_to_def<I: Into<StdItem>>(&self, item: I) -> DefId {
+    let item = item.into();
+    self.item_to_def[item.index()]
+  }
+
+  #[inline]
+  pub(super) fn def_to_item_opt(&self, def_id: DefId) -> Option<StdItem> {
+    self.def_to_item.get(&def_id).copied()
+  }
+
+  #[inline]
+  pub(super) fn is_one_of(&self, def_id: DefId, items: &[StdItem]) -> bool {
+    items.iter().any(|&item| self.item_to_def(item) == def_id)
+  }
+}

--- a/stainless_extraction/src/ty.rs
+++ b/stainless_extraction/src/ty.rs
@@ -1,9 +1,7 @@
+use super::std_items::StdItem::*;
 use super::*;
 
 use rustc_ast::ast;
-use rustc_hir::lang_items::{
-  FnMutTraitLangItem, FnOnceTraitLangItem, FnTraitLangItem, SizedTraitLangItem,
-};
 use rustc_middle::ty::{
   AdtDef, GenericParamDef, GenericParamDefKind, Generics, PredicateKind, Ty, TyKind,
 };
@@ -47,8 +45,19 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
     let f = self.factory();
     match ty.kind {
       TyKind::Bool => f.BooleanType().into(),
+
       TyKind::Adt(adt_def, _) if self.is_bigint(adt_def) => f.IntegerType().into(),
+      TyKind::Int(ast::IntTy::I8) => f.BVType(true, 8).into(),
+      TyKind::Int(ast::IntTy::I16) => f.BVType(true, 16).into(),
       TyKind::Int(ast::IntTy::I32) => f.BVType(true, 32).into(),
+      TyKind::Int(ast::IntTy::I64) => f.BVType(true, 64).into(),
+      TyKind::Int(ast::IntTy::I128) => f.BVType(true, 128).into(),
+      TyKind::Uint(ast::UintTy::U8) => f.BVType(false, 8).into(),
+      TyKind::Uint(ast::UintTy::U16) => f.BVType(false, 16).into(),
+      TyKind::Uint(ast::UintTy::U32) => f.BVType(false, 32).into(),
+      TyKind::Uint(ast::UintTy::U64) => f.BVType(false, 64).into(),
+      TyKind::Uint(ast::UintTy::U128) => f.BVType(false, 128).into(),
+
       TyKind::Tuple(..) => {
         let arg_tps = self.extract_tys(ty.tuple_fields(), txtcx, span);
         match arg_tps.len() {
@@ -60,11 +69,13 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
           _ => f.TupleType(arg_tps).into(),
         }
       }
+
       TyKind::Adt(adt_def, substs) => {
         let sort = self.extract_adt(adt_def.did);
         let arg_tps = self.extract_tys(substs.types(), txtcx, span);
         f.ADTType(sort.id, arg_tps).into()
       }
+
       TyKind::Param(param_ty) => txtcx
         .index_to_tparam
         .get(&param_ty.index)
@@ -123,10 +134,8 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
     let all_params = all_generic_params_of(tcx, def_id);
 
     // Certain unextracted traits we don't complain about at all.
-    let should_silently_ignore_trait = |trait_did: DefId| {
-      let check = |lang_item| trait_did == tcx.require_lang_item(lang_item, None);
-      check(SizedTraitLangItem)
-    };
+    let should_silently_ignore_trait =
+      |trait_did: DefId| self.std_items.is_one_of(trait_did, &[SizedTrait]);
 
     // Discovering HOF parameters.
     // We extract `F: Fn*(S) -> T` trait predicates by replacing `F` by `S => T`.
@@ -240,9 +249,9 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
   /// Various helpers
 
   pub(super) fn is_fn_like_trait(&self, def_id: DefId) -> bool {
-    let tcx = self.tcx;
-    let check = |lang_item| def_id == tcx.require_lang_item(lang_item, None);
-    check(FnTraitLangItem) || check(FnMutTraitLangItem) || check(FnOnceTraitLangItem)
+    self
+      .std_items
+      .is_one_of(def_id, &[FnTrait, FnMutTrait, FnOnceTrait])
   }
 
   pub(super) fn is_bv_type(&self, ty: Ty<'tcx>) -> bool {

--- a/stainless_frontend/src/bin/cargo-stainless.rs
+++ b/stainless_frontend/src/bin/cargo-stainless.rs
@@ -4,6 +4,7 @@ extern crate serde_json;
 use clap::{App, Arg};
 use serde_json::{Map, Value};
 use std::collections::HashMap;
+use std::env;
 use std::fs;
 use std::path::PathBuf;
 use std::process::*;
@@ -240,6 +241,14 @@ fn main() -> ! {
 
   if let Some(export_path) = config.export_path_opt {
     build.env.insert("RUSTSTAINLESS_EXPORT".into(), export_path);
+  }
+
+  // Pass through certain flags
+  for &var_name in &["STAINLESS_FLAGS"] {
+    if let Ok(value) = env::var(var_name) {
+      let var_name: String = var_name.into();
+      build.env.entry(var_name).or_insert(value);
+    }
   }
 
   let status = Command::new("rustc_to_stainless")

--- a/stainless_frontend/tests/extraction_tests.rs
+++ b/stainless_frontend/tests/extraction_tests.rs
@@ -79,6 +79,7 @@ define_tests!(
   pass: fact,
   pass: generic_id,
   pass: generic_option,
+  pass: int_operators,
   pass: int_option,
   pass: tuples,
   fail_extraction: switch_ref,

--- a/stainless_frontend/tests/pass/int_operators.rs
+++ b/stainless_frontend/tests/pass/int_operators.rs
@@ -1,0 +1,89 @@
+extern crate stainless;
+
+pub fn i32_ops(x: i32, y: i32) {
+  assert!(x + y == y + x);
+  assert!(x + x == 2 * x);
+  assert!(x + x == x << 1);
+  if x >= 0 && x < 1<<30 {
+    assert!(x == (x + x) / 2);
+  }
+
+  assert!(x - y == -y + x);
+  assert!(x - x == 0);
+
+  assert!(x * y == y * x);
+  assert!(x == 0 || x % x == 0);
+
+  if x > 0 && x < 128 && y >= 0 && y <= 128 {
+    assert!((x * y) % x == 0);
+  }
+
+  assert!(x | y == y | x);
+  assert!(x | x == x);
+
+  assert!(x & y == y & x);
+  assert!(x & x == x);
+  assert!(x & 0 == 0);
+
+  assert!(x ^ y == y ^ x);
+  assert!(x ^ x == 0);
+
+  // FIXME: Enable once missing case in Stainless typechecker is added
+  // assert!(x == !!x);
+}
+
+pub fn u32_ops(x: u32, y: u32) {
+  assert!(x + y == y + x);
+  assert!(x + x == 2 * x);
+  assert!(x + x == x << 1u32);
+  assert!(x >= 1<<31u32 || x == (x + x) / 2);
+
+  assert!(x - x == 0);
+
+  assert!(x * y == y * x);
+  assert!(x == 0 || x % x == 0);
+
+  assert!(x | y == y | x);
+  assert!(x | x == x);
+
+  assert!(x & y == y & x);
+  assert!(x & x == x);
+  assert!(x & 0 == 0);
+
+  assert!(x ^ y == y ^ x);
+  assert!(x ^ x == 0);
+
+  // FIXME: Enable once missing case in Stainless typechecker is added
+  // assert!(x == !!x);
+  // assert!(x - y == !y + x);
+}
+
+// Test the widening of shift operands
+
+pub fn shift_operand_u8_8(x: u8, y: u8) -> u8 { x << y }
+
+pub fn shift_operand_u16_8(x: u16, y: u8) -> u16 { x << y }
+pub fn shift_operand_u16_16(x: u16, y: u16) -> u16 { x << y }
+
+pub fn shift_operand_u32_8(x: u32, y: u8) -> u32 { x << y }
+pub fn shift_operand_u32_16(x: u32, y: u16) -> u32 { x << y }
+pub fn shift_operand_u32_32(x: u32, y: u32) -> u32 { x << y }
+
+pub fn shift_operand_u64_8(x: u64, y: u8) -> u64 { x >> y }
+pub fn shift_operand_u64_16(x: u64, y: u16) -> u64 { x >> y }
+pub fn shift_operand_u64_32(x: u64, y: u32) -> u64 { x >> y }
+pub fn shift_operand_u64_64(x: u64, y: u64) -> u64 { x >> y }
+
+pub fn shift_operand_i8_8(x: i8, y: i8) -> i8 { x << y }
+
+pub fn shift_operand_i16_8(x: i16, y: i8) -> i16 { x << y }
+pub fn shift_operand_i16_16(x: i16, y: i16) -> i16 { x << y }
+
+pub fn shift_operand_i32_8(x: i32, y: i8) -> i32 { x << y }
+pub fn shift_operand_i32_16(x: i32, y: i16) -> i32 { x << y }
+pub fn shift_operand_i32_32(x: i32, y: i32) -> i32 { x << y }
+
+pub fn shift_operand_i64_8(x: i64, y: i8) -> i64 { x >> y }
+pub fn shift_operand_i64_16(x: i64, y: i16) -> i64 { x >> y }
+pub fn shift_operand_i64_32(x: i64, y: i32) -> i64 { x >> y }
+pub fn shift_operand_i64_64(x: i64, y: i64) -> i64 { x >> y }


### PR DESCRIPTION
Besides the changes in the title, this PR also includes infrastructure for "standard items", which generalize rustc's internal idea of "lang items", i.e., certain items in the standard library that the compiler explicitly refers to internally. Various items that we would like to check for are not lang items, however, thus the generalization.