### PR TITLE
Sanitise path names for z3

### DIFF
--- a/stainless_extraction/src/expr.rs
+++ b/stainless_extraction/src/expr.rs
@@ -31,7 +31,7 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
       ExprKind::Tuple { .. } => self.extract_tuple(expr),
       ExprKind::Field { .. } => self.extract_field(expr),
       ExprKind::VarRef { id } => self.fetch_var(id).into(),
-      ExprKind::Call { ty, args, .. } => self.extract_call_like(ty, &args, expr.span),
+      ExprKind::Call { ty, ref args, .. } => self.extract_call_like(ty, args, expr.span),
       ExprKind::Adt { .. } => self.extract_adt_construction(expr),
       ExprKind::Block { body: ast_block } => {
         let block = self.mirror(ast_block);
@@ -362,7 +362,7 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
     // Special case for Box::new, erase it and return the argument directly.
     // TODO: turn Box::new to a StdItem and use that. Tracked here:
     //  https://github.com/epfl-lara/rust-stainless/issues/34
-    if fd_id.symbol_path == ["std", "boxed", "Box", "<T>", "new"] {
+    if fd_id.symbol_path == ["std", "boxed", "Box", "T", "new"] {
       return self.extract_expr_ref(args.first().cloned().unwrap());
     }
 

--- a/stainless_extraction/src/krate.rs
+++ b/stainless_extraction/src/krate.rs
@@ -544,7 +544,7 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
   pub(super) fn extract_adt_id(&mut self, def_id: DefId) -> &'l st::SymbolIdentifier<'l> {
     self
       // get known ID
-      .with_extraction(|xt| xt.mapping.did_to_stid.get(&def_id).copied())
+      .get_id_from_def(def_id)
       // otherwise extract ADT, then get the ID
       .unwrap_or_else(|| &self.extract_adt(def_id).id)
   }
@@ -552,9 +552,8 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
   /// Extract an ADT (regardless of whether it is local or external)
   pub(super) fn extract_adt(&mut self, def_id: DefId) -> &'l st::ADTSort<'l> {
     let sort_opt = self.with_extraction(|xt| {
-      xt.mapping
-        .did_to_stid
-        .get(&def_id)
+      self
+        .get_id_from_def(def_id)
         .and_then(|id| xt.adts.get(id).copied())
     });
 

--- a/stainless_extraction/src/lib.rs
+++ b/stainless_extraction/src/lib.rs
@@ -134,6 +134,10 @@ struct BaseExtractor<'l, 'tcx: 'l> {
 fn sanitize_path_name(s: &String) -> String {
   // Remove forbidden characters
   let s = s.replace(&[' ', '<', '>'][..], "");
+  assert!(
+    !s.is_empty(),
+    "Path name must have at least one alphanumeric character."
+  );
 
   // Prepend an underscore to numerical-only identifiers for compatibility
   // with stainless


### PR DESCRIPTION
Z3 doesn't like numerical only identifiers, this was already dealt with. It also doesn't like `<, >, _, ' '`. This PR streamlines name sanitising.

This PR depends on changes made in #58.