### PR TITLE
Extract simple let type ascriptions

### DIFF
--- a/stainless_frontend/tests/extraction_tests.rs
+++ b/stainless_frontend/tests/extraction_tests.rs
@@ -86,6 +86,7 @@ define_tests!(
   pass: insertion_sort,
   pass: int_operators,
   pass: int_option,
+  pass: let_type,
   pass: list_binary_search,
   pass: nested_spec,
   pass: nested_spec_impl,

--- a/stainless_frontend/tests/pass/let_type.rs
+++ b/stainless_frontend/tests/pass/let_type.rs
@@ -1,0 +1,19 @@
+extern crate stainless;
+
+pub enum List<T> {
+  Nil,
+  Cons(T, Box<List<T>>),
+}
+
+pub fn main() {
+  let a: u32 = 1234;
+
+  let boxx: Box<List<i64>> = Box::new(List::Cons(-123, Box::new(List::Nil)));
+
+  let c: i64 = match *boxx {
+    List::Cons(a, _) => a,
+    List::Nil => 0,
+  };
+
+  assert!(a == 1234 && c == -123)
+}


### PR DESCRIPTION
A very simplistic implementation, but it will be needed for the possibly new approach to specs as blocks.

Closes #53.