### PR TITLE
[fix] Allow struct to be used before declared

### DIFF
--- a/stainless_extraction/src/krate.rs
+++ b/stainless_extraction/src/krate.rs
@@ -629,7 +629,7 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
       Some(sort) => sort,
       None => {
         let f = self.factory();
-        let adt_id = self.register_def(def_id);
+        let adt_id = self.get_or_register_def(def_id);
         let adt_def = self.tcx.adt_def(def_id);
 
         // Extract flags

--- a/stainless_frontend/tests/extraction_tests.rs
+++ b/stainless_frontend/tests/extraction_tests.rs
@@ -73,6 +73,7 @@ macro_rules! define_tests {
 //  - fail_extraction: ensures that extraction rejects the program
 //  - fail_verification: ensures that verification rejects the program
 define_tests!(
+  pass: adt_use_before_declare,
   pass: adts,
   pass: blocks,
   pass: boxes,

--- a/stainless_frontend/tests/pass/adt_use_before_declare.rs
+++ b/stainless_frontend/tests/pass/adt_use_before_declare.rs
@@ -1,0 +1,11 @@
+extern crate stainless;
+
+pub enum SomeEnum {
+  Uses(ThatStruct),
+  OrUsesNothing,
+  But(ThatStruct),
+  IsOnlyDefined,
+  Afterwards,
+}
+
+pub struct ThatStruct(u64);


### PR DESCRIPTION
There was a crash if a struct was used in a field before it was declared (see the added test). This is now fixed.