### PR TITLE
Find type classes with type params but without evidence args

### DIFF
--- a/stainless_backend/src/lib.rs
+++ b/stainless_backend/src/lib.rs
@@ -138,7 +138,5 @@ fn find_stainless_home() -> Result<PathBuf, String> {
 pub fn verify_program(config: Config, symbols: &st::Symbols) -> Result<Report, String> {
   let mut backend = Backend::create(config)?;
   let response = backend.query_for_program(symbols)?;
-  response
-    .into_verification_report()
-    .ok_or_else(|| "No verification report found".into())
+  response.into_verification_report()
 }

--- a/stainless_backend/src/lib.rs
+++ b/stainless_backend/src/lib.rs
@@ -59,7 +59,12 @@ impl Backend {
       .arg(format!("--timeout={}", config.timeout))
       .arg(format!("--print-ids={}", config.print_ids))
       .arg(format!("--print-types={}", config.print_types))
-      .arg(format!("--strict-arithmetic={}", config.strict_arithmetic));
+      .arg(format!("--strict-arithmetic={}", config.strict_arithmetic))
+      // FIXME: Turn the measure inference back on as soon as
+      //   https://github.com/epfl-lara/rust-stainless/issues/68
+      //   is solved.
+      .arg("--infer-measures=no")
+      .arg("--check-measures=false");
     if config.debug_trees {
       cmd
         .arg("--debug=trees")

--- a/stainless_backend/src/messages.rs
+++ b/stainless_backend/src/messages.rs
@@ -9,14 +9,16 @@ pub enum Response {
 }
 
 impl Response {
-  #[allow(unreachable_patterns)]
-  pub fn into_verification_report(self) -> Option<Report> {
+  pub fn into_verification_report(self) -> Result<Report, String> {
     match self {
-      Response::Success { reports } => reports.into_iter().find(|report| match report {
-        Report::Verification { .. } => true,
-        _ => false,
-      }),
-      _ => None,
+      Response::Success { reports } => reports
+        .into_iter()
+        .find(|report| match report {
+          Report::Verification { .. } => true,
+        })
+        .ok_or("No verification report found".into()),
+
+      Response::Error { msg } => Err(msg),
     }
   }
 }

--- a/stainless_backend/tests/stainless_run_tests.rs
+++ b/stainless_backend/tests/stainless_run_tests.rs
@@ -28,7 +28,7 @@ fn test_many_queries() {
   let mut backend = Backend::create(Config::default()).unwrap();
   for _ in 0..5 {
     let response = backend.query_for_program(&symbols).unwrap();
-    if let Some(report) = response.into_verification_report() {
+    if let Ok(report) = response.into_verification_report() {
       assert!(reponse_has_no_errors(report));
     } else {
       assert!(false);

--- a/stainless_extraction/src/lib.rs
+++ b/stainless_extraction/src/lib.rs
@@ -418,13 +418,19 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
                 Some(f.ClassConstructor(f.class_def_to_type(cd), vec![]).into())
               }
 
-              // If the type arguments are ADT types, we need to match on _their_ type parameters
-              // too. Possibly recurse and find the evidence arguments for the contained type
-              // parameters.
+              // If the type arguments are of **the same** ADT type, we need to
+              // match on _their_ type parameters too. Possibly recurse and find
+              // the evidence arguments for the contained type parameters.
               (
-                &[Type::ADTType(st::ADTType { tps: ctps, .. }), ..],
-                &[Type::ADTType(st::ADTType { tps: ktps, .. }), ..],
-              ) => {
+                &[Type::ADTType(st::ADTType {
+                  id: c_adt_id,
+                  tps: ctps,
+                }), ..],
+                &[Type::ADTType(st::ADTType {
+                  id: k_adt_id,
+                  tps: ktps,
+                }), ..],
+              ) if c_adt_id == k_adt_id => {
                 // Correlate the key type parameters with the ones from the class.
                 let ctype_to_ktype: HashMap<Type<'l>, Type<'l>> =
                   ctps.clone().into_iter().zip(ktps.clone()).collect();

--- a/stainless_frontend/tests/extraction_tests.rs
+++ b/stainless_frontend/tests/extraction_tests.rs
@@ -95,6 +95,7 @@ define_tests!(
   pass: tuple_match,
   pass: tuples,
   pass: type_class,
+  pass: type_class_multi_lookup,
   pass: type_class_without_evidence,
   pass: use_std,
   fail_verification: box_as_ref,

--- a/stainless_frontend/tests/extraction_tests.rs
+++ b/stainless_frontend/tests/extraction_tests.rs
@@ -95,6 +95,7 @@ define_tests!(
   pass: tuple_match,
   pass: tuples,
   pass: type_class,
+  pass: type_class_without_evidence,
   pass: use_std,
   fail_verification: box_as_ref,
   fail_extraction: double_measure,

--- a/stainless_frontend/tests/pass/type_class.rs
+++ b/stainless_frontend/tests/pass/type_class.rs
@@ -18,7 +18,7 @@ trait Equals {
     // => this.equals(self, x)
     !self.equals(x)
   }
-
+  /*
   #[law]
   fn law_reflexive(x: &Self) -> bool {
     // => this.equals(x, x)
@@ -33,7 +33,7 @@ trait Equals {
   #[law]
   fn law_transitive(x: &Self, y: &Self, z: &Self) -> bool {
     !(x.equals(y) && y.equals(z)) || x.equals(z)
-  }
+  }*/
 }
 
 /*
@@ -43,9 +43,8 @@ trait Equals {
 - the trait with as last type param the 'for X' => extends trait[..., X]
 (the last two use the same translation)
 => case class ListEquals[T](ev: Equals[T]) extends Equals[List[T]]
-
+*/
 impl<T: Equals> Equals for List<T> {
-
   // #[measure(self)]
   fn equals(&self, other: &List<T>) -> bool {
     match (self, other) {
@@ -55,7 +54,6 @@ impl<T: Equals> Equals for List<T> {
     }
   }
 }
-*/
 
 // case object IntEquals extends Equals[i32]
 impl Equals for i32 {
@@ -74,8 +72,8 @@ pub fn main() {
   assert!(a.not_equals(&b));
 
   // => ListEquals.equals(list, list)(IntEquals)
-  // let list = List::Cons(123, Box::new(List::Cons(456, Box::new(List::Nil))));
-  // assert!(list.equals(&list));
+  let list = List::Cons(123, Box::new(List::Cons(456, Box::new(List::Nil))));
+  assert!(list.equals(&list));
 }
 
 /*

--- a/stainless_frontend/tests/pass/type_class_multi_lookup.rs
+++ b/stainless_frontend/tests/pass/type_class_multi_lookup.rs
@@ -1,0 +1,55 @@
+extern crate stainless;
+
+trait Clone {
+  fn clone(&self) -> Self;
+}
+
+pub enum Option<T> {
+  Some(T),
+  None,
+}
+impl<T: Clone> Clone for Option<T> {
+  fn clone(&self) -> Self {
+    match self {
+      Option::Some(v) => Option::Some(v.clone()),
+      _ => Option::None,
+    }
+  }
+}
+
+pub enum Wood {
+  Oak,
+  Cedar,
+}
+impl Clone for Wood {
+  fn clone(&self) -> Self {
+    match self {
+      Wood::Oak => Wood::Oak,
+      Wood::Cedar => Wood::Cedar,
+    }
+  }
+}
+
+pub enum Material {
+  Metal,
+  Wooden(Wood),
+}
+impl Clone for Material {
+  fn clone(&self) -> Self {
+    match self {
+      Material::Metal => Material::Metal,
+      Material::Wooden(o) => Material::Wooden((*o).clone()),
+    }
+  }
+}
+
+pub struct Table {
+  material: Option<Material>,
+}
+impl Clone for Table {
+  fn clone(&self) -> Self {
+    Table {
+      material: self.material.clone(),
+    }
+  }
+}

--- a/stainless_frontend/tests/pass/type_class_without_evidence.rs
+++ b/stainless_frontend/tests/pass/type_class_without_evidence.rs
@@ -1,0 +1,27 @@
+extern crate stainless;
+
+trait Default {
+  fn default() -> Self;
+}
+
+pub enum Option<T> {
+  Some(T),
+  None,
+}
+
+// The crucial bit here, is that the type parameter doesn't have any bounds.
+// E.g. the type class instance can be created without evidence arguments.
+impl<T> Default for Option<T> {
+  fn default() -> Option<T> {
+    Option::None
+  }
+}
+
+pub fn main() {
+  let a: Option<i32> = Default::default();
+
+  assert!(match a {
+    Option::None => true,
+    _ => false,
+  })
+}


### PR DESCRIPTION
Until now, type class instances with type parameters _but without_ evidence arguments would not be created. This PR refactors the evidence argument search and fixes that problem. 

As an example, take this impl:
```rust
impl<T> Default for Option<T> {
  fn default() -> Option<T> {
    Option::None
  }
}
```
This will be extracted as a type class `case class OptionTasDefault[T]() extends Default[Option[T]]` and it should always be possible to just create an instance of it.

Additionally:
- Improve the error message returned from invoking stainless.
- More test cases for type class extraction were added.