### PR TITLE
Fix non-deterministic order of type parameters

### DIFF
--- a/demo/examples/generic_result.rs
+++ b/demo/examples/generic_result.rs
@@ -1,0 +1,31 @@
+extern crate stainless;
+use stainless::*;
+
+// These are just here, because the bug was triggered more easily with more
+// stuff to extract.
+trait Clone {
+  fn clone(&self) -> Self;
+}
+trait Default {
+  fn default() -> Self;
+}
+pub trait Equals {
+  fn eq(&self, other: &Self) -> bool;
+}
+
+pub enum Result<T, E> {
+  Ok(T),
+  Err(E),
+}
+
+impl<T, E> Result<T, E> {
+  #[post(self.is_ok() == ret)]
+  pub fn is_ok(&self) -> bool {
+    match self {
+      Result::Ok(_) => true,
+      _ => false,
+    }
+  }
+}
+
+pub fn main() {}

--- a/stainless_extraction/src/ty.rs
+++ b/stainless_extraction/src/ty.rs
@@ -8,6 +8,8 @@ use rustc_middle::ty::{
 };
 use rustc_span::{Span, DUMMY_SP};
 
+use std::collections::BTreeMap;
+
 use stainless_data::ast as st;
 
 /// Extraction of types
@@ -32,8 +34,10 @@ impl<'a, 'l> From<&'a TyParam<'l>> for st::Type<'l> {
 pub(super) struct TyExtractionCtxt<'l> {
   /// The DefId of the surrounding item,
   pub(super) def_id: DefId,
-  /// A mapping from parameter indices to stainless type parameters
-  pub(super) index_to_tparam: HashMap<u32, TyParam<'l>>,
+
+  /// A mapping from parameter indices to stainless type parameters, this should
+  /// be ordered by the index, hence BTreeMap.
+  pub(super) index_to_tparam: BTreeMap<u32, TyParam<'l>>,
 }
 
 impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
@@ -151,7 +155,7 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
         vec![],
         TyExtractionCtxt {
           def_id,
-          index_to_tparam: HashMap::new(),
+          index_to_tparam: BTreeMap::new(),
         },
         vec![],
       );
@@ -220,7 +224,7 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
     }
 
     // Extract TypeParameterDefs for all normal generic parameters (ignoring HOF parameters)
-    let index_to_tparam: HashMap<u32, TyParam<'l>> = all_generic_params_of(tcx, def_id)
+    let index_to_tparam: BTreeMap<u32, TyParam<'l>> = all_generic_params_of(tcx, def_id)
       .iter()
       .filter_map(|param| match &param.kind {
         GenericParamDefKind::Type { .. } => {

--- a/stainless_frontend/tests/extraction_tests.rs
+++ b/stainless_frontend/tests/extraction_tests.rs
@@ -83,6 +83,7 @@ define_tests!(
   pass: fn_ref_param,
   pass: generic_id,
   pass: generic_option,
+  pass: generic_result,
   pass: impl_fns,
   pass: insertion_sort,
   pass: int_operators,

--- a/stainless_frontend/tests/pass/generic_result.rs
+++ b/stainless_frontend/tests/pass/generic_result.rs
@@ -1,0 +1,31 @@
+extern crate stainless;
+use stainless::*;
+
+// These are just here, because the bug was triggered more easily with more
+// stuff to extract.
+trait Clone {
+  fn clone(&self) -> Self;
+}
+trait Default {
+  fn default() -> Self;
+}
+pub trait Equals {
+  fn eq(&self, other: &Self) -> bool;
+}
+
+pub enum Result<T, E> {
+  Ok(T),
+  Err(E),
+}
+
+impl<T, E> Result<T, E> {
+  #[post(self.is_ok() == ret)]
+  pub fn is_ok(&self) -> bool {
+    match self {
+      Result::Ok(_) => true,
+      _ => false,
+    }
+  }
+}
+
+pub fn main() {}


### PR DESCRIPTION
The use of a HashMap in generics extraction lead to the bug that type parameters were not always in the same order. The bug only appeared on some runs of the program. This PR fixes the behaviour by using a `BTreeMap`.