### PR TITLE
Refactor std items to use path comparison

### DIFF
--- a/stainless_extraction/src/expr.rs
+++ b/stainless_extraction/src/expr.rs
@@ -1,6 +1,4 @@
 use super::literal::Literal;
-use super::std_items::StdItem;
-use super::std_items::StdItem::*;
 use super::*;
 
 use crate::spec::SpecType;
@@ -8,8 +6,9 @@ use crate::spec::SpecType;
 use std::convert::TryFrom;
 
 use rustc_middle::mir::{BinOp, BorrowKind, Mutability, UnOp};
-use rustc_middle::ty::{subst::SubstsRef, Ty, TyKind};
+use rustc_middle::ty::{subst::SubstsRef, Ty, TyKind, TyS};
 
+use crate::std_items::{CrateItem, LangItem, StdItem};
 use crate::ty::{int_bit_width, uint_bit_width};
 use rustc_hair::hair::{
   Arm, BindingMode, Block, BlockSafety, Expr, ExprKind, ExprRef, FieldPat, FruInfo, Guard,
@@ -32,7 +31,21 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
       ExprKind::Tuple { .. } => self.extract_tuple(expr),
       ExprKind::Field { .. } => self.extract_field(expr),
       ExprKind::VarRef { id } => self.fetch_var(id).into(),
-      ExprKind::Call { ty, ref args, .. } => self.extract_call_like(ty, args, expr.span),
+
+      ExprKind::Call {
+        ty: TyS {
+          kind: TyKind::FnDef(def_id, substs_ref),
+          ..
+        },
+        ref args,
+        ..
+      } => self.extract_call_like(*def_id, substs_ref, args, expr.span),
+
+      ExprKind::Call { .. } => self.unsupported_expr(
+        expr.span,
+        "Cannot extract call without statically known target",
+      ),
+
       ExprKind::Adt { .. } => self.extract_adt_construction(expr),
       ExprKind::Block { body: ast_block } => {
         let block = self.mirror(ast_block);
@@ -275,43 +288,49 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
 
   fn extract_call_like(
     &mut self,
-    ty: Ty<'tcx>,
+    def_id: DefId,
+    substs_ref: SubstsRef<'tcx>,
     args: &Vec<ExprRef<'tcx>>,
     span: Span,
   ) -> st::Expr<'l> {
-    if let TyKind::FnDef(def_id, substs_ref) = ty.kind {
-      // If the call is a std item, extract it specially
-      match self.base.std_items.def_to_item_opt(def_id) {
-        Some(BeginPanicFn) => self.extract_panic(args, span, false),
-        Some(BeginPanicFmtFn) => self.extract_panic(args, span, true),
-
-        Some(SetEmptyFn) | Some(SetSingletonFn) => {
-          self.extract_set_creation(args, substs_ref, span)
+    // If the call is a std item, extract it specially
+    self
+      .base
+      .std_items
+      .def_to_item_opt(def_id)
+      .and_then(|sti| match sti {
+        StdItem::LangItem(LangItem::BeginPanicFn) => Some(self.extract_panic(args, span, false)),
+        StdItem::CrateItem(CrateItem::BeginPanicFmtFn) => {
+          Some(self.extract_panic(args, span, true))
         }
-        Some(std_item)
-          if std_item == SetAddFn
-            || std_item == SetDifferenceFn
-            || std_item == SetIntersectionFn
-            || std_item == SetUnionFn
-            || std_item == SubsetOfFn =>
+
+        StdItem::CrateItem(CrateItem::SetEmptyFn)
+        | StdItem::CrateItem(CrateItem::SetSingletonFn) => {
+          Some(self.extract_set_creation(args, substs_ref, span))
+        }
+        StdItem::CrateItem(item)
+          if item == CrateItem::SetAddFn
+            || item == CrateItem::SetDifferenceFn
+            || item == CrateItem::SetIntersectionFn
+            || item == CrateItem::SetUnionFn
+            || item == CrateItem::SubsetOfFn =>
         {
-          self.extract_set_op(std_item, args, span)
+          Some(self.extract_set_op(item, args, span))
         }
-
-        // Otherwise, extract a normal call
-        _ => self.extract_call(def_id, substs_ref, args, span),
-      }
-    } else {
-      self.unsupported_expr(span, "Cannot extract call without statically known target")
-    }
+        _ => None,
+      })
+      // Otherwise, extract a normal call
+      .unwrap_or_else(|| self.extract_call(def_id, substs_ref, args, span))
   }
 
   fn extract_set_op(
     &mut self,
-    std_item: StdItem,
+    std_item: CrateItem,
     args: &Vec<ExprRef<'tcx>>,
     span: Span,
   ) -> st::Expr<'l> {
+    use CrateItem::*;
+
     if let [set, arg, ..] = &self.extract_expr_refs(args.to_vec())[0..2] {
       return match std_item {
         SetAddFn => self.factory().SetAdd(*set, *arg).into(),

--- a/stainless_extraction/src/lib.rs
+++ b/stainless_extraction/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(rustc_private)]
 #![feature(box_patterns)]
+#![feature(bool_to_option)]
 
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
After some discussion with @gsps, we settled on this middle-ground:

- Std item detection is still done by enumerating all def_ids of used crates (currently `std` and `stainless`). I.e. #48 remains open.
- However, now we compare `def_path_str` instead of just the last name in the path, which closes #43.
- Additionally, this adds a distinction between crate items and lang items which makes the detection more readable.

This PR will unlock the solution to #34, #69 as well as #70, because it will remove the need to do things like:

```rust 
 if fd_id.symbol_path == ["std", "boxed", "Box", "<T>", "new"] ...
```