### PR TITLE
Cache extracted generics.

### DIFF
--- a/stainless_extraction/src/classes.rs
+++ b/stainless_extraction/src/classes.rs
@@ -19,7 +19,11 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
     let f = self.factory();
 
     let id = self.get_or_register_def(def_id);
-    let (tparams, tyxtctx, trait_bounds) = self.extract_generics(def_id);
+    let Generics {
+      tparams,
+      txtcx,
+      trait_bounds,
+    } = self.get_generics(def_id);
 
     // If this is an 'impl for trait', we extract a concrete class
     if let Some(ty::TraitRef {
@@ -29,7 +33,7 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
     {
       // The parent (aka inherits from) the trait it implements
       let trait_id = self.get_or_register_def(trait_def_id);
-      let tps = self.extract_tys(substs.types(), &tyxtctx, span);
+      let tps = self.extract_tys(substs.types(), &txtcx, span);
       let parent = vec![&*f.ClassType(trait_id, tps)];
 
       let fields = trait_bounds

--- a/stainless_extraction/src/krate.rs
+++ b/stainless_extraction/src/krate.rs
@@ -294,7 +294,7 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
     let f = self.factory();
 
     // Extract the function signature
-    let (tparams, txtcx, _) = self.extract_generics(def_id);
+    let Generics { tparams, txtcx, .. } = self.get_generics(def_id);
     let poly_fn_sig = self.tcx.fn_sig(def_id);
     let fn_sig = self.tcx.liberate_late_bound_regions(def_id, &poly_fn_sig);
     let params: Params<'l> = fn_sig
@@ -335,7 +335,7 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
 
     // Extract the function itself
     type Parts<'l> = (Params<'l>, st::Type<'l>, st::Expr<'l>);
-    let (tparams, txtcx, _) = self.extract_generics(fn_item.def_id);
+    let Generics { tparams, txtcx, .. } = self.get_generics(fn_item.def_id);
 
     let (params, return_tpe, body_expr): Parts<'l> =
       self.enter_body(hir_id, txtcx.clone(), class_def, |bxtor| {
@@ -421,7 +421,7 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
         };
 
         // Extract generics
-        let (tparams, txtcx, _) = self.extract_generics(def_id);
+        let Generics { tparams, txtcx, .. } = self.get_generics(def_id);
 
         // Extract constructors
         let constructors = adt_def

--- a/stainless_extraction/src/lib.rs
+++ b/stainless_extraction/src/lib.rs
@@ -46,7 +46,7 @@ use bindings::DefContext;
 use fns::TypeClassKey;
 use stainless_data::ast::Type;
 use std_items::StdItems;
-use ty::TyExtractionCtxt;
+use ty::{Generics, TyExtractionCtxt};
 use utils::UniqueCounter;
 
 /// The entrypoint into extraction
@@ -83,6 +83,7 @@ type StainlessSymId<'l> = &'l st::SymbolIdentifier<'l>;
 type Params<'l> = Vec<&'l st::ValDef<'l>>;
 
 /// A mapping between Rust ids and Stainless ids
+#[derive(Default)]
 struct SymbolMapping<'l> {
   global_id_counter: UniqueCounter<()>,
   local_id_counter: UniqueCounter<String>,
@@ -97,6 +98,7 @@ struct Extraction<'l> {
   adts: HashMap<StainlessSymId<'l>, &'l st::ADTSort<'l>>,
   function_refs: HashSet<DefId>,
   method_to_class: HashMap<StainlessSymId<'l>, &'l st::ClassDef<'l>>,
+  generics: HashMap<StainlessSymId<'l>, Generics<'l>>,
   functions: HashMap<StainlessSymId<'l>, &'l st::FunDef<'l>>,
   classes: HashMap<StainlessSymId<'l>, &'l st::ClassDef<'l>>,
 }
@@ -104,18 +106,14 @@ struct Extraction<'l> {
 impl<'l> Extraction<'l> {
   fn new(factory: &'l st::Factory) -> Self {
     Self {
-      mapping: SymbolMapping {
-        global_id_counter: UniqueCounter::new(),
-        local_id_counter: UniqueCounter::new(),
-        did_to_stid: HashMap::new(),
-        hid_to_stid: HashMap::new(),
-      },
       factory,
-      adts: HashMap::new(),
-      function_refs: HashSet::new(),
-      functions: HashMap::new(),
-      classes: HashMap::new(),
-      method_to_class: HashMap::new(),
+      mapping: Default::default(),
+      adts: Default::default(),
+      function_refs: Default::default(),
+      method_to_class: Default::default(),
+      generics: Default::default(),
+      functions: Default::default(),
+      classes: Default::default(),
     }
   }
 

--- a/stainless_extraction/src/ty.rs
+++ b/stainless_extraction/src/ty.rs
@@ -4,7 +4,8 @@ use super::*;
 use rustc_ast::ast;
 use rustc_hir::Mutability;
 use rustc_middle::ty::{
-  AdtDef, GenericParamDef, GenericParamDefKind, Generics, PredicateKind, TraitRef, Ty, TyKind,
+  AdtDef, GenericParamDef, GenericParamDefKind, Generics as RustGenerics, PredicateKind, TraitRef,
+  Ty, TyKind,
 };
 use rustc_span::{Span, DUMMY_SP};
 
@@ -38,6 +39,13 @@ pub(super) struct TyExtractionCtxt<'l> {
   /// A mapping from parameter indices to stainless type parameters, this should
   /// be ordered by the index, hence BTreeMap.
   pub(super) index_to_tparam: BTreeMap<u32, TyParam<'l>>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct Generics<'l> {
+  pub tparams: Vec<&'l st::TypeParameterDef<'l>>,
+  pub txtcx: TyExtractionCtxt<'l>,
+  pub trait_bounds: Vec<&'l st::ClassType<'l>>,
 }
 
 impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
@@ -130,16 +138,22 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
       .collect()
   }
 
-  /// Generics
+  /// Get the extracted generics for a def_id, usually a function or a class.
+  /// Generics are cached after the first computation.
+  pub(super) fn get_generics(&mut self, def_id: DefId) -> Generics<'l> {
+    let id = self.get_or_register_def(def_id);
 
-  pub(super) fn extract_generics(
-    &mut self,
-    def_id: DefId,
-  ) -> (
-    Vec<&'l st::TypeParameterDef<'l>>,
-    TyExtractionCtxt<'l>,
-    Vec<&'l st::ClassType<'l>>,
-  ) {
+    // FIXME: There was no easy solution to convince the borrow checker to
+    //   return a reference to the generics instead of cloning them.
+    self
+      .with_extraction(|xt| xt.generics.get(id).cloned())
+      .unwrap_or_else(|| {
+        let gen = self.extract_generics(def_id);
+        self.with_extraction_mut(|xt| xt.generics.entry(id).or_insert(gen).clone())
+      })
+  }
+
+  fn extract_generics(&mut self, def_id: DefId) -> Generics<'l> {
     let f = self.factory();
     let tcx = self.tcx;
     let span = tcx.span_of_impl(def_id).unwrap_or(DUMMY_SP);
@@ -151,14 +165,14 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
     if tcx.is_closure(def_id) {
       assert_eq!(generics.count(), 3);
       assert_eq!(predicates.predicates.len(), 0);
-      return (
-        vec![],
-        TyExtractionCtxt {
+      return Generics {
+        tparams: vec![],
+        txtcx: TyExtractionCtxt {
           def_id,
           index_to_tparam: BTreeMap::new(),
         },
-        vec![],
-      );
+        trait_bounds: vec![],
+      };
     }
 
     // Certain unextracted traits we don't complain about at all.
@@ -271,7 +285,7 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
     }
 
     // Convert trait refs in the trait bounds to types
-    let bounds: Vec<&'l st::ClassType<'l>> = trait_bounds
+    let trait_bounds: Vec<&'l st::ClassType<'l>> = trait_bounds
       .iter()
       // Filter out the Self-trait-bound that rustc puts on traits
       .filter(|&(tr, _)| tr.def_id != def_id)
@@ -284,8 +298,8 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
       .collect();
 
     // And we're done.
-    (
-      txtcx
+    Generics {
+      tparams: txtcx
         .index_to_tparam
         .values()
         .filter_map(|tparam| match tparam {
@@ -294,8 +308,8 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
         })
         .collect(),
       txtcx,
-      bounds,
-    )
+      trait_bounds,
+    }
   }
 
   /// Various helpers
@@ -337,7 +351,7 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
 
 pub fn all_generic_params_of(tcx: TyCtxt<'_>, def_id: DefId) -> Vec<&GenericParamDef> {
   let generics = tcx.generics_of(def_id);
-  let mut all_generics: Vec<&Generics> = vec![generics];
+  let mut all_generics: Vec<&RustGenerics> = vec![generics];
   while let Some(parent_id) = all_generics.last().unwrap().parent {
     all_generics.push(tcx.generics_of(parent_id));
   }

--- a/stainless_extraction/src/utils.rs
+++ b/stainless_extraction/src/utils.rs
@@ -4,17 +4,12 @@ use std::hash::Hash;
 pub type Counter = i32;
 
 /// UniqueCounter provides fresh ids with a name prefix
+#[derive(Default)]
 pub struct UniqueCounter<K: Hash + Eq> {
   next: HashMap<K, Counter>,
 }
 
 impl<K: Clone + Hash + Eq> UniqueCounter<K> {
-  pub fn new() -> Self {
-    Self {
-      next: HashMap::new(),
-    }
-  }
-
   pub fn fresh(&mut self, k: &K) -> Counter {
     // *self.next.entry(k).and_modify(|c| *c += 1).or_insert(0)
     match self.next.get_mut(k) {


### PR DESCRIPTION
Generics become more important with type classes and evidence parameters, they need to be accessible in multiple places. To provide for that, we cache the generics in the extraction.
This is a preliminary PR for #93 .