### PR TITLE
Extract usize/isize type and expressions

### DIFF
--- a/stainless_extraction/src/expr.rs
+++ b/stainless_extraction/src/expr.rs
@@ -22,7 +22,7 @@ type Result<T> = std::result::Result<T, &'static str>;
 impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
   pub(super) fn extract_expr(&mut self, expr: Expr<'tcx>) -> st::Expr<'l> {
     match expr.kind {
-      ExprKind::Literal { literal: konst, .. } => match Literal::from(konst, self.tcx()) {
+      ExprKind::Literal { literal: konst, .. } => match Literal::from_const(konst, self.tcx()) {
         Some(lit) => lit.as_st_literal(self.factory()),
         _ => self.unsupported_expr(expr.span, "Unsupported kind of literal"),
       },
@@ -632,7 +632,7 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
         ),
       },
 
-      box PatKind::Constant { value: konst } => match Literal::from(konst, self.tcx()) {
+      box PatKind::Constant { value: konst } => match Literal::from_const(konst, self.tcx()) {
         Some(lit) => f.LiteralPattern(binder, lit.as_st_literal(f)).into(),
         _ => self.unsupported_pattern(pattern.span, "Unsupported kind of literal in pattern"),
       },
@@ -799,7 +799,7 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
       && scrutinee.ty.is_bool()
       && match (&arms[0].pattern.kind, &arms[1].pattern.kind) {
         (box PatKind::Constant { value: konst }, box PatKind::Wild) => {
-          match Literal::from(*konst, self.tcx()) {
+          match Literal::from_const(*konst, self.tcx()) {
             Some(Literal::Bool(b)) => b,
             _ => false,
           }

--- a/stainless_extraction/src/literal.rs
+++ b/stainless_extraction/src/literal.rs
@@ -30,7 +30,7 @@ impl Literal {
     }
   }
 
-  pub fn from(konst: &ty::Const<'_>, tcx: TyCtxt<'_>) -> Option<Self> {
+  pub fn from_const(konst: &ty::Const<'_>, tcx: TyCtxt<'_>) -> Option<Self> {
     match konst.ty.kind {
       _ if konst.ty.is_unit() => Some(Literal::Unit),
 

--- a/stainless_extraction/src/literal.rs
+++ b/stainless_extraction/src/literal.rs
@@ -1,9 +1,8 @@
-use std::convert::TryFrom;
-
 use rustc_middle::mir::interpret::ConstValue;
-use rustc_middle::ty::{self, ConstKind, TyKind};
+use rustc_middle::ty::{self, ConstKind, TyCtxt, TyKind};
 use rustc_target::abi;
 
+use crate::ty::{int_bit_width, uint_bit_width};
 use stainless_data::ast as st;
 use stainless_data::ser::types as st_types;
 
@@ -30,36 +29,30 @@ impl Literal {
       Literal::String(value) => f.StringLiteral(value.clone()).into(),
     }
   }
-}
 
-impl<'tcx> TryFrom<&'tcx ty::Const<'tcx>> for Literal {
-  type Error = ();
-
-  fn try_from(konst: &'tcx ty::Const<'tcx>) -> Result<Self, Self::Error> {
+  pub fn from(konst: &ty::Const<'_>, tcx: TyCtxt<'_>) -> Option<Self> {
     match konst.ty.kind {
-      _ if konst.ty.is_unit() => Ok(Literal::Unit),
+      _ if konst.ty.is_unit() => Some(Literal::Unit),
+
       TyKind::Bool => {
         let value = konst.val.try_to_bits(abi::Size::from_bits(1)).unwrap() == 1;
-        Ok(Literal::Bool(value))
+        Some(Literal::Bool(value))
       }
-      // TODO: Handle `isize` and `usize`
-      TyKind::Int(int_ty) => int_ty
-        .bit_width()
-        .and_then(|size| {
-          let value = konst.val.try_to_bits(abi::Size::from_bits(size));
-          value.map(|value| Literal::Int {
-            value: value as i128,
-            size,
-          })
+
+      TyKind::Int(int_ty) => {
+        let size = int_bit_width(int_ty, tcx);
+        let value = konst.val.try_to_bits(abi::Size::from_bits(size));
+        value.map(|value| Literal::Int {
+          value: value as i128,
+          size,
         })
-        .ok_or(()),
-      TyKind::Uint(uint_ty) => uint_ty
-        .bit_width()
-        .and_then(|size| {
-          let value = konst.val.try_to_bits(abi::Size::from_bits(size));
-          value.map(|value| Literal::Uint { value, size })
-        })
-        .ok_or(()),
+      }
+      TyKind::Uint(uint_ty) => {
+        let size = uint_bit_width(uint_ty, tcx);
+        let value = konst.val.try_to_bits(abi::Size::from_bits(size));
+        value.map(|value| Literal::Uint { value, size })
+      }
+
       TyKind::Ref(
         _,
         ty::TyS {
@@ -70,11 +63,11 @@ impl<'tcx> TryFrom<&'tcx ty::Const<'tcx>> for Literal {
         ConstKind::Value(ConstValue::Slice { data, start, end }) => {
           let slice = data.inspect_with_undef_and_ptr_outside_interpreter(start..end);
           let s = ::std::str::from_utf8(slice).expect("Expected UTF8 str in ConstValue");
-          Ok(Literal::String(s.into()))
+          Some(Literal::String(s.into()))
         }
-        _ => Err(()),
+        _ => None,
       },
-      _ => Err(()),
+      _ => None,
     }
   }
 }

--- a/stainless_extraction/src/ty.rs
+++ b/stainless_extraction/src/ty.rs
@@ -48,13 +48,15 @@ pub(super) struct Generics<'l> {
   pub trait_bounds: Vec<&'l st::ClassType<'l>>,
 }
 
+#[inline]
 fn usize_bit_width(tcx: TyCtxt<'_>) -> u64 {
   tcx.data_layout.pointer_size.bits()
 }
-
+#[inline]
 pub fn int_bit_width(int_ty: ast::IntTy, tcx: TyCtxt<'_>) -> u64 {
   int_ty.bit_width().unwrap_or(usize_bit_width(tcx))
 }
+#[inline]
 pub fn uint_bit_width(int_ty: ast::UintTy, tcx: TyCtxt<'_>) -> u64 {
   int_ty.bit_width().unwrap_or(usize_bit_width(tcx))
 }
@@ -72,19 +74,12 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
 
       // Integer types
       TyKind::Adt(adt_def, _) if self.is_bigint(adt_def) => f.IntegerType().into(),
-      TyKind::Int(ast::IntTy::I8) => f.BVType(true, 8).into(),
-      TyKind::Int(ast::IntTy::I16) => f.BVType(true, 16).into(),
-      TyKind::Int(ast::IntTy::I32) => f.BVType(true, 32).into(),
-      TyKind::Int(ast::IntTy::I64) => f.BVType(true, 64).into(),
-      TyKind::Int(ast::IntTy::I128) => f.BVType(true, 128).into(),
-      TyKind::Uint(ast::UintTy::U8) => f.BVType(false, 8).into(),
-      TyKind::Uint(ast::UintTy::U16) => f.BVType(false, 16).into(),
-      TyKind::Uint(ast::UintTy::U32) => f.BVType(false, 32).into(),
-      TyKind::Uint(ast::UintTy::U64) => f.BVType(false, 64).into(),
-      TyKind::Uint(ast::UintTy::U128) => f.BVType(false, 128).into(),
-
-      TyKind::Int(ast::IntTy::Isize) => f.BVType(true, usize_bit_width(self.tcx) as i32).into(),
-      TyKind::Uint(ast::UintTy::Usize) => f.BVType(false, usize_bit_width(self.tcx) as i32).into(),
+      TyKind::Int(int_ty) => f
+        .BVType(true, int_bit_width(int_ty, self.tcx) as i32)
+        .into(),
+      TyKind::Uint(uint_ty) => f
+        .BVType(false, uint_bit_width(uint_ty, self.tcx) as i32)
+        .into(),
 
       TyKind::Tuple(..) => {
         let arg_tps = self.extract_tys(ty.tuple_fields(), txtcx, span);

--- a/stainless_extraction/src/ty.rs
+++ b/stainless_extraction/src/ty.rs
@@ -48,17 +48,25 @@ pub(super) struct Generics<'l> {
   pub trait_bounds: Vec<&'l st::ClassType<'l>>,
 }
 
+/// The width in bits of a pointer and hence also usize/isize. See [here for more details](
+/// https://rust-lang.github.io/unsafe-code-guidelines/layout/scalars.html?highlight=usize#isize-and-usize)
 #[inline]
-fn usize_bit_width(tcx: TyCtxt<'_>) -> u64 {
+fn pointer_bit_width(tcx: TyCtxt<'_>) -> u64 {
   tcx.data_layout.pointer_size.bits()
 }
+
+/// Get the bit width of an integer type (signed) which is either the hardcoded
+/// `bit_width` in `ast` or the width of an isize, see [pointer_bit_width()].
 #[inline]
 pub fn int_bit_width(int_ty: ast::IntTy, tcx: TyCtxt<'_>) -> u64 {
-  int_ty.bit_width().unwrap_or(usize_bit_width(tcx))
+  int_ty.bit_width().unwrap_or(pointer_bit_width(tcx))
 }
+
+/// Get the bit width of an integer type (unsigned) which is either the hardcoded
+/// `bit_width` in `ast` or the width of an usize, see [pointer_bit_width()].
 #[inline]
 pub fn uint_bit_width(int_ty: ast::UintTy, tcx: TyCtxt<'_>) -> u64 {
-  int_ty.bit_width().unwrap_or(usize_bit_width(tcx))
+  int_ty.bit_width().unwrap_or(pointer_bit_width(tcx))
 }
 
 impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {

--- a/stainless_extraction/src/ty.rs
+++ b/stainless_extraction/src/ty.rs
@@ -56,6 +56,7 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
     span: Span,
   ) -> st::Type<'l> {
     let f = self.factory();
+    let usize_bits = self.tcx.data_layout.pointer_size.bits() as i32;
     match ty.kind {
       TyKind::Bool => f.BooleanType().into(),
 
@@ -71,6 +72,9 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
       TyKind::Uint(ast::UintTy::U32) => f.BVType(false, 32).into(),
       TyKind::Uint(ast::UintTy::U64) => f.BVType(false, 64).into(),
       TyKind::Uint(ast::UintTy::U128) => f.BVType(false, 128).into(),
+
+      TyKind::Int(ast::IntTy::Isize) => f.BVType(true, usize_bits).into(),
+      TyKind::Uint(ast::UintTy::Usize) => f.BVType(false, usize_bits).into(),
 
       TyKind::Tuple(..) => {
         let arg_tps = self.extract_tys(ty.tuple_fields(), txtcx, span);

--- a/stainless_frontend/tests/pass/int_operators.rs
+++ b/stainless_frontend/tests/pass/int_operators.rs
@@ -4,7 +4,7 @@ pub fn i32_ops(x: i32, y: i32) {
   assert!(x + y == y + x);
   assert!(x + x == 2 * x);
   assert!(x + x == x << 1);
-  if x >= 0 && x < 1<<30 {
+  if x >= 0 && x < 1 << 30 {
     assert!(x == (x + x) / 2);
   }
 
@@ -36,7 +36,33 @@ pub fn u32_ops(x: u32, y: u32) {
   assert!(x + y == y + x);
   assert!(x + x == 2 * x);
   assert!(x + x == x << 1u32);
-  assert!(x >= 1<<31u32 || x == (x + x) / 2);
+  assert!(x >= 1 << 31u32 || x == (x + x) / 2);
+
+  assert!(x - x == 0);
+
+  assert!(x * y == y * x);
+  assert!(x == 0 || x % x == 0);
+
+  assert!(x | y == y | x);
+  assert!(x | x == x);
+
+  assert!(x & y == y & x);
+  assert!(x & x == x);
+  assert!(x & 0 == 0);
+
+  assert!(x ^ y == y ^ x);
+  assert!(x ^ x == 0);
+
+  // FIXME: Enable once missing case in Stainless typechecker is added
+  // assert!(x == !!x);
+  // assert!(x - y == !y + x);
+}
+
+pub fn usize_ops(x: usize, y: usize) {
+  assert!(x + y == y + x);
+  assert!(x + x == 2 * x);
+  assert!(x + x == x << 1u32);
+  assert!(x >= 1 << 31u32 || x == (x + x) / 2);
 
   assert!(x - x == 0);
 
@@ -60,30 +86,70 @@ pub fn u32_ops(x: u32, y: u32) {
 
 // Test the widening of shift operands
 
-pub fn shift_operand_u8_8(x: u8, y: u8) -> u8 { x << y }
+pub fn shift_operand_u8_8(x: u8, y: u8) -> u8 {
+  x << y
+}
 
-pub fn shift_operand_u16_8(x: u16, y: u8) -> u16 { x << y }
-pub fn shift_operand_u16_16(x: u16, y: u16) -> u16 { x << y }
+pub fn shift_operand_u16_8(x: u16, y: u8) -> u16 {
+  x << y
+}
+pub fn shift_operand_u16_16(x: u16, y: u16) -> u16 {
+  x << y
+}
 
-pub fn shift_operand_u32_8(x: u32, y: u8) -> u32 { x << y }
-pub fn shift_operand_u32_16(x: u32, y: u16) -> u32 { x << y }
-pub fn shift_operand_u32_32(x: u32, y: u32) -> u32 { x << y }
+pub fn shift_operand_u32_8(x: u32, y: u8) -> u32 {
+  x << y
+}
+pub fn shift_operand_u32_16(x: u32, y: u16) -> u32 {
+  x << y
+}
+pub fn shift_operand_u32_32(x: u32, y: u32) -> u32 {
+  x << y
+}
 
-pub fn shift_operand_u64_8(x: u64, y: u8) -> u64 { x >> y }
-pub fn shift_operand_u64_16(x: u64, y: u16) -> u64 { x >> y }
-pub fn shift_operand_u64_32(x: u64, y: u32) -> u64 { x >> y }
-pub fn shift_operand_u64_64(x: u64, y: u64) -> u64 { x >> y }
+pub fn shift_operand_u64_8(x: u64, y: u8) -> u64 {
+  x >> y
+}
+pub fn shift_operand_u64_16(x: u64, y: u16) -> u64 {
+  x >> y
+}
+pub fn shift_operand_u64_32(x: u64, y: u32) -> u64 {
+  x >> y
+}
+pub fn shift_operand_u64_64(x: u64, y: u64) -> u64 {
+  x >> y
+}
 
-pub fn shift_operand_i8_8(x: i8, y: i8) -> i8 { x << y }
+pub fn shift_operand_i8_8(x: i8, y: i8) -> i8 {
+  x << y
+}
 
-pub fn shift_operand_i16_8(x: i16, y: i8) -> i16 { x << y }
-pub fn shift_operand_i16_16(x: i16, y: i16) -> i16 { x << y }
+pub fn shift_operand_i16_8(x: i16, y: i8) -> i16 {
+  x << y
+}
+pub fn shift_operand_i16_16(x: i16, y: i16) -> i16 {
+  x << y
+}
 
-pub fn shift_operand_i32_8(x: i32, y: i8) -> i32 { x << y }
-pub fn shift_operand_i32_16(x: i32, y: i16) -> i32 { x << y }
-pub fn shift_operand_i32_32(x: i32, y: i32) -> i32 { x << y }
+pub fn shift_operand_i32_8(x: i32, y: i8) -> i32 {
+  x << y
+}
+pub fn shift_operand_i32_16(x: i32, y: i16) -> i32 {
+  x << y
+}
+pub fn shift_operand_i32_32(x: i32, y: i32) -> i32 {
+  x << y
+}
 
-pub fn shift_operand_i64_8(x: i64, y: i8) -> i64 { x >> y }
-pub fn shift_operand_i64_16(x: i64, y: i16) -> i64 { x >> y }
-pub fn shift_operand_i64_32(x: i64, y: i32) -> i64 { x >> y }
-pub fn shift_operand_i64_64(x: i64, y: i64) -> i64 { x >> y }
+pub fn shift_operand_i64_8(x: i64, y: i8) -> i64 {
+  x >> y
+}
+pub fn shift_operand_i64_16(x: i64, y: i16) -> i64 {
+  x >> y
+}
+pub fn shift_operand_i64_32(x: i64, y: i32) -> i64 {
+  x >> y
+}
+pub fn shift_operand_i64_64(x: i64, y: i64) -> i64 {
+  x >> y
+}

--- a/stainless_frontend/tests/pass/int_operators.rs
+++ b/stainless_frontend/tests/pass/int_operators.rs
@@ -32,6 +32,38 @@ pub fn i32_ops(x: i32, y: i32) {
   // assert!(x == !!x);
 }
 
+pub fn isize_ops(x: isize, y: isize) {
+  assert!(x + y == y + x);
+  assert!(x + x == 2 * x);
+  assert!(x + x == x << 1);
+  if x >= 0 && x < 1 << 30 {
+    assert!(x == (x + x) / 2);
+  }
+
+  assert!(x - y == -y + x);
+  assert!(x - x == 0);
+
+  assert!(x * y == y * x);
+  assert!(x == 0 || x % x == 0);
+
+  if x > 0 && x < 128 && y >= 0 && y <= 128 {
+    assert!((x * y) % x == 0);
+  }
+
+  assert!(x | y == y | x);
+  assert!(x | x == x);
+
+  assert!(x & y == y & x);
+  assert!(x & x == x);
+  assert!(x & 0 == 0);
+
+  assert!(x ^ y == y ^ x);
+  assert!(x ^ x == 0);
+
+  // FIXME: Enable once missing case in Stainless typechecker is added
+  // assert!(x == !!x);
+}
+
 pub fn u32_ops(x: u32, y: u32) {
   assert!(x + y == y + x);
   assert!(x + x == 2 * x);
@@ -61,8 +93,8 @@ pub fn u32_ops(x: u32, y: u32) {
 pub fn usize_ops(x: usize, y: usize) {
   assert!(x + y == y + x);
   assert!(x + x == 2 * x);
-  assert!(x + x == x << 1u32);
-  assert!(x >= 1 << 31u32 || x == (x + x) / 2);
+  assert!(x + x == x << 1usize);
+  assert!(x >= 1 << 31usize || x == (x + x) / 2);
 
   assert!(x - x == 0);
 


### PR DESCRIPTION
Thanks to rustc's data layout, we can take the actual target bit width.

Closes #75.