### PR TITLE
Fix specs on trait bounded fns and impls

### DIFF
--- a/stainless_extraction/src/spec.rs
+++ b/stainless_extraction/src/spec.rs
@@ -110,7 +110,6 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
       }
 
       // Register all other bindings
-      assert_eq!(outer_fn_params.len(), spec_param_ids.len());
       for (vd, sid) in outer_fn_params.iter().zip(spec_param_ids) {
         bxtor.dcx.add_var(sid, vd.v);
       }

--- a/stainless_frontend/tests/pass/trait_bounds.rs
+++ b/stainless_frontend/tests/pass/trait_bounds.rs
@@ -1,4 +1,5 @@
 extern crate stainless;
+use stainless::*;
 
 pub enum List<T> {
   Nil,
@@ -7,6 +8,11 @@ pub enum List<T> {
 
 pub trait Equals {
   fn eq(&self, other: &Self) -> bool;
+
+  #[law]
+  fn law_reflexive(x: &Self) -> bool {
+    x.eq(x)
+  }
 }
 
 impl Equals for i32 {
@@ -47,6 +53,31 @@ impl<T: Equals> List<T> {
         }
       }
       _ => s.hash(),
+    }
+  }
+}
+
+#[post(ret == 123)]
+pub fn fn_with_bound_and_spec<T: Equals>(x: &T) -> i32 {
+  if x.eq(x) {
+    123
+  } else {
+    123
+  }
+}
+
+impl<T: Equals> List<T> {
+  #[post(ret == 123)]
+  pub fn fn_with_bound_and_spec(&self) -> i32 {
+    match self {
+      List::Nil => 123,
+      List::Cons(x, _) => {
+        if x.eq(x) {
+          123
+        } else {
+          123
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
As the evidence arguments are added to the function, the function and the spec can now have a different number of arguments.