### PR TITLE
Extract PhantomData as a local ADT

### DIFF
--- a/stainless_extraction/src/expr.rs
+++ b/stainless_extraction/src/expr.rs
@@ -8,7 +8,7 @@ use std::convert::TryFrom;
 use rustc_middle::mir::{BinOp, BorrowKind, Mutability, UnOp};
 use rustc_middle::ty::{subst::SubstsRef, Ty, TyKind, TyS};
 
-use crate::std_items::{CrateItem, LangItem, StdItem};
+use crate::std_items::LangItem;
 use crate::ty::{int_bit_width, uint_bit_width};
 use rustc_hair::hair::{
   Arm, BindingMode, Block, BlockSafety, Expr, ExprKind, ExprRef, FieldPat, FruInfo, Guard,

--- a/stainless_extraction/src/krate.rs
+++ b/stainless_extraction/src/krate.rs
@@ -2,7 +2,7 @@ use super::*;
 
 use rustc_hir::def_id::DefId;
 use rustc_hir::itemlikevisit::ItemLikeVisitor;
-use rustc_hir::{self as hir, AssocItemKind, Defaultness, ItemKind};
+use rustc_hir::{self as hir, def, AssocItemKind, Defaultness, ItemKind};
 use rustc_hir_pretty as pretty;
 use rustc_middle::ty::{AssocKind, List};
 use rustc_span::DUMMY_SP;
@@ -26,7 +26,9 @@ fn should_ignore(item: &hir::Item<'_>) -> bool {
     }
     ItemKind::Use(ref path, _) => {
       let path_str = pretty_path(path);
-      path_str.contains("std::prelude") || path_str.starts_with("stainless")
+      path_str.contains("std::prelude")
+        || path_str.starts_with("std::marker::PhantomData")
+        || path_str.starts_with("stainless")
     }
     // TODO: Quick fix to filter our synthetic functions
     // ItemKind::Fn(..) if !item.attrs.is_empty() => true,
@@ -49,7 +51,23 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
         let def_path_str = self.xtor.tcx.def_path_str(def_id);
 
         match &item.kind {
-          // Ignore use and external crates.
+          // Special known use statements
+          ItemKind::Use(
+            hir::Path {
+              res: def::Res::Def(def::DefKind::Struct, def_id),
+              ..
+            },
+            _,
+          ) => {
+            // Extract the 'use PhantomData' statement as the PhantomData ADT definition.
+            if let Some(StdItem::CrateItem(CrateItem::PhantomData)) =
+              self.xtor.std_items.def_to_item_opt(*def_id)
+            {
+              self.xtor.get_or_extract_adt(*def_id);
+            }
+          }
+
+          // Ignore some known use statements and external crates.
           _ if should_ignore(item) => {}
 
           // Store top-level functions

--- a/stainless_extraction/src/lib.rs
+++ b/stainless_extraction/src/lib.rs
@@ -46,7 +46,7 @@ use stainless_data::ast as st;
 use bindings::DefContext;
 use fns::TypeClassKey;
 use stainless_data::ast::Type;
-use std_items::StdItems;
+use std_items::{CrateItem, StdItem, StdItems};
 use ty::{Generics, TyExtractionCtxt};
 use utils::UniqueCounter;
 

--- a/stainless_extraction/src/std_items.rs
+++ b/stainless_extraction/src/std_items.rs
@@ -34,6 +34,7 @@ pub enum CrateItem {
   SetEmptyFn,
   SetSingletonFn,
   BoxNew,
+  PhantomData,
 }
 
 use CrateItem::*;
@@ -52,6 +53,7 @@ impl CrateItem {
       SetEmptyFn => "stainless::Set::<T>::empty",
       SetSingletonFn => "stainless::Set::<T>::singleton",
       BoxNew => "std::boxed::Box::<T>::new",
+      PhantomData => "std::marker::PhantomData",
     }
   }
 
@@ -61,6 +63,7 @@ impl CrateItem {
   pub fn crate_name(&self) -> &'static str {
     match self {
       BoxNew => "alloc",
+      PhantomData => "core",
       _ => self.path().splitn(2, "::").next().unwrap(),
     }
   }

--- a/stainless_extraction/src/ty.rs
+++ b/stainless_extraction/src/ty.rs
@@ -9,7 +9,6 @@ use rustc_span::{Span, DUMMY_SP};
 
 use std::collections::BTreeMap;
 
-use crate::std_items::{CrateItem, StdItem};
 use stainless_data::ast as st;
 
 /// Extraction of types

--- a/stainless_frontend/tests/extraction_tests.rs
+++ b/stainless_frontend/tests/extraction_tests.rs
@@ -94,6 +94,7 @@ define_tests!(
   pass: nested_spec,
   pass: nested_spec_impl,
   pass: panic_type,
+  pass: phantom_data,
   pass: spec_on_trait_impl,
   pass: trait_bounds,
   pass: struct_update,

--- a/stainless_frontend/tests/pass/phantom_data.rs
+++ b/stainless_frontend/tests/pass/phantom_data.rs
@@ -1,0 +1,22 @@
+extern crate stainless;
+
+use std::marker::PhantomData;
+
+pub struct Foo<T>(i32, PhantomData<T>);
+
+pub struct Bar<T> {
+  a: i32,
+  _marker: PhantomData<T>,
+}
+
+pub fn main() {
+  let foo: Foo<u32> = Foo(-123, PhantomData);
+
+  let bar: Bar<bool> = Bar {
+    a: 123,
+    _marker: PhantomData,
+  };
+
+  assert!(foo.0 == -123);
+  assert!(bar.a == 123)
+}


### PR DESCRIPTION
PhantomData is just a field-less marker, so it is safe to extract it as a field-less ADT.
The trick used here, is that we detect the 
```rust
use std::marker::PhantomData
```
and extract it as 
```Scala
case class PhantomData[T]()
```

Closes #69.

The awesome thing is, that the existing `extract_adt` function also works for crate-external ADTs. (Therefore, the feature addition in the last commit of this PR is minimal effort.) This opens the door to using the real `std::*::Option/Result/`etc. Tracking that feature here: https://github.com/epfl-lara/rust-stainless/issues/103


(As always, there's a preliminary clean-up commit, which _can/may_ be reviewed separately.)