### PR TITLE
Support early return statements

### DIFF
--- a/stainless_data/src/ser.rs
+++ b/stainless_data/src/ser.rs
@@ -109,17 +109,20 @@ pub trait Serializer: Sized {
 
   // Particulars of the stainless serializer
 
-  // TODO: Support values >= 255 (see inox serializer)
+  /// Writes the marker with the same algorithm as in the Inox serializer.
+  /// See [here](https://github.com/epfl-lara/inox/blob/master/src/main/scala/inox/utils/Serialization.scala#L181-L190).
   fn write_marker(&mut self, marker: MarkerId) -> SerializationResult {
-    let id: u32 = marker.0;
-    assert!(id < 255);
-    self.write_u8(id as u8)?;
-    Ok(())
+    let mut id: u32 = marker.0;
+    while id >= 255 {
+      self.write_u8(255 as u8)?;
+      id -= 255
+    }
+    self.write_u8(id as u8)
   }
 
   // A way of writing lengths biased towards small values
   fn write_length(&mut self, len: usize) -> SerializationResult {
-    assert!(len <= (std::i32::MAX as usize));
+    assert!(len <= i32::MAX as usize);
     if len < 255 {
       self.write_u8(len as u8)?;
     } else {

--- a/stainless_extraction/src/expr.rs
+++ b/stainless_extraction/src/expr.rs
@@ -84,6 +84,8 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
 
       ExprKind::Assign { lhs, rhs } => self.extract_assignment(lhs, rhs),
 
+      ExprKind::Return { value } => self.extract_return(value),
+
       _ => self.unsupported_expr(
         expr.span,
         format!("Cannot extract expr kind {:?}", expr.kind),
@@ -430,6 +432,13 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
         .FunctionInvocation(fd_id, arg_tps_without_parents, args)
         .into(),
     }
+  }
+
+  fn extract_return(&mut self, value: Option<ExprRef<'tcx>>) -> st::Expr<'l> {
+    let expr = value
+      .map(|v| self.extract_expr_ref(v))
+      .unwrap_or_else(|| self.factory().UnitLiteral().into());
+    self.factory().Return(expr).into()
   }
 
   fn extract_arg_types<I>(&mut self, types: I, span: Span) -> Vec<st::Type<'l>>

--- a/stainless_extraction/src/expr.rs
+++ b/stainless_extraction/src/expr.rs
@@ -47,8 +47,8 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
       ),
 
       ExprKind::Adt { .. } => self.extract_adt_construction(expr),
-      ExprKind::Block { body: ast_block } => {
-        let block = self.mirror(ast_block);
+      ExprKind::Block { body } => {
+        let block = self.mirror(body);
         match block.safety_mode {
           BlockSafety::Safe => self.extract_block(block),
           _ => self.unsupported_expr(expr.span, "Cannot extract unsafe block"),
@@ -799,17 +799,40 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
     }
   }
 
-  fn extract_block(&mut self, block: Block<'tcx>) -> st::Expr<'l> {
-    let Block {
+  fn extract_block(
+    &mut self,
+    Block {
       mut stmts,
       expr: final_expr,
       ..
-    } = block;
+    }: Block<'tcx>,
+  ) -> st::Expr<'l> {
     let final_expr = final_expr
       .map(|e| self.extract_expr_ref(e))
+      // If there's no final expression, we need to check whether the last
+      // statement is a return. If yes, we take the return as final expression.
+      .or_else(|| {
+        stmts
+          .last()
+          .cloned()
+          .and_then(|s| match self.mirror(s).kind {
+            StmtKind::Expr { expr, .. } => Some(expr),
+            _ => None,
+          })
+          .and_then(|expr| {
+            let expr = self.mirror(expr);
+            match self.strip_scope(expr).kind {
+              ExprKind::Return { value } => {
+                stmts.pop();
+                Some(self.extract_return(value))
+              }
+              _ => None,
+            }
+          })
+      })
       .unwrap_or_else(|| self.factory().UnitLiteral().into());
-    stmts.reverse();
 
+    stmts.reverse();
     let mut spec_ids = HashMap::new();
     let body_expr = self.extract_block_(&mut stmts, &mut vec![], &mut spec_ids, final_expr);
     self.extract_specs(&spec_ids, body_expr)

--- a/stainless_frontend/tests/extraction_tests.rs
+++ b/stainless_frontend/tests/extraction_tests.rs
@@ -99,6 +99,7 @@ define_tests!(
   pass: nested_spec_impl,
   pass: panic_type,
   pass: phantom_data,
+  pass: return_stmt,
   pass: spec_on_trait_impl,
   pass: trait_bounds,
   pass: struct_update,

--- a/stainless_frontend/tests/extraction_tests.rs
+++ b/stainless_frontend/tests/extraction_tests.rs
@@ -24,19 +24,38 @@ macro_rules! select_check {
   (fail, verification, $test_path:ident) => {
     emit_check!(true, ErrorInVerification, $test_path)
   };
+  (crash, verification, $test_path:ident) => {
+    emit_check!(true, CrashInVerification, $test_path)
+  };
+}
+
+macro_rules! test_folder {
+  (crash) => {
+    "fail"
+  };
+  ($outcome:ident) => {
+    stringify!($outcome)
+  };
+}
+
+macro_rules! relative_path {
+  ($outcome:ident, $name:ident) => {
+    concat!(
+      "tests/",
+      test_folder!($outcome),
+      "/",
+      stringify!($name),
+      ".rs"
+    )
+  };
 }
 
 macro_rules! define_test {
-  ($pass_or_fail:ident, $stage:ident, $test_name:ident, $name:ident) => {
+  ($outcome:ident, $stage:ident, $test_name:ident, $name:ident) => {
     #[test]
     fn $test_name() {
-      let relative_path = format!(
-        "tests/{}/{}.rs",
-        stringify!($pass_or_fail),
-        stringify!($name)
-      );
-      let test_path = manifest_relative_path(relative_path);
-      select_check!($pass_or_fail, $stage, test_path);
+      let test_path = manifest_relative_path(relative_path!($outcome, $name));
+      select_check!($outcome, $stage, test_path);
     }
   };
 }
@@ -54,6 +73,9 @@ macro_rules! select_test {
   };
   (fail_verification, $name:ident) => {
     define_test!(fail, verification, $name, $name);
+  };
+  (crash_verification, $name:ident) => {
+    define_test!(crash, verification, $name, $name);
   };
 }
 
@@ -116,5 +138,7 @@ define_tests!(
   fail_verification: liskov_rectangle,
   fail_extraction: mut_borrow_ref,
   fail_extraction: mut_params,
+  crash_verification: return_in_cond,
+  crash_verification: return_in_guard,
   fail_extraction: user_deref
 );

--- a/stainless_frontend/tests/fail/return_in_cond.rs
+++ b/stainless_frontend/tests/fail/return_in_cond.rs
@@ -1,0 +1,13 @@
+extern crate stainless;
+
+fn bar() -> i32 {
+  if 12 == 12 && return 0 {
+    return 1;
+  } else {
+    return 2;
+  }
+}
+
+pub fn main() {
+  assert!(bar() == 0)
+}

--- a/stainless_frontend/tests/fail/return_in_guard.rs
+++ b/stainless_frontend/tests/fail/return_in_guard.rs
@@ -1,0 +1,15 @@
+extern crate stainless;
+
+#[allow(unused_variables)]
+fn foo(x: Option<i32>) -> i32 {
+  match x {
+    Option::Some(i) if return 0 => i,
+    Option::Some(_) => 42,
+    Option::None => -42,
+  }
+}
+
+pub fn main() {
+  assert!(foo(Option::Some(123)) == 0);
+  assert!(foo(Option::None) == -42)
+}

--- a/stainless_frontend/tests/pass/return_stmt.rs
+++ b/stainless_frontend/tests/pass/return_stmt.rs
@@ -25,3 +25,18 @@ pub fn return_when_wanted(arg: u32) {
 
   panic!("will never reach me")
 }
+
+pub fn return_pattern_match(arg: u32) -> i32 {
+  let s = match arg {
+    1 => return 1,
+    i if 3 <= i && i <= 10 => 100000,
+    a => {
+      if a > 1000 {
+        return 2;
+      }
+      10000000
+    }
+  };
+  assert!(s >= 100000);
+  s
+}

--- a/stainless_frontend/tests/pass/return_stmt.rs
+++ b/stainless_frontend/tests/pass/return_stmt.rs
@@ -1,0 +1,27 @@
+extern crate stainless;
+use stainless::*;
+
+#[pre(x >= 0 && x < 10)]
+#[post(ret >= 0)]
+pub fn fact(x: i32) -> i32 {
+  if x <= 0 {
+    return 1;
+  }
+
+  fact(x - 1) * x
+}
+
+pub fn return_when_wanted(arg: u32) {
+  if arg < 10 {
+    return;
+  }
+  let a = 1;
+  let useless = 3;
+  let computation = useless + a;
+
+  if computation > 3 {
+    return;
+  }
+
+  panic!("will never reach me")
+}

--- a/stainless_frontend/tests/pass/return_stmt.rs
+++ b/stainless_frontend/tests/pass/return_stmt.rs
@@ -1,6 +1,11 @@
 extern crate stainless;
 use stainless::*;
 
+pub enum Option<T> {
+  None,
+  Some(T),
+}
+
 #[pre(x >= 0 && x < 10)]
 #[post(ret >= 0)]
 pub fn fact(x: i32) -> i32 {
@@ -39,4 +44,20 @@ pub fn return_pattern_match(arg: u32) -> i32 {
   };
   assert!(s >= 100000);
   s
+}
+
+pub fn does_not_consume(option: &Option<i32>, v: i32) -> bool {
+  match option {
+    Option::None => {}
+    Option::Some(x) => return *x == v,
+  };
+  false
+}
+
+pub fn flatten<T>(opt: Option<Option<T>>) -> Option<T> {
+  match opt {
+    Option::Some(maybe) => return maybe,
+    _ => {}
+  }
+  return Option::None;
 }

--- a/stainless_frontend/tests/pass/return_stmt.rs
+++ b/stainless_frontend/tests/pass/return_stmt.rs
@@ -61,26 +61,3 @@ pub fn flatten<T>(opt: Option<Option<T>>) -> Option<T> {
   }
   return Option::None;
 }
-
-#[allow(unused_variables)]
-fn foo(x: Option<i32>) -> i32 {
-  match x {
-    Option::Some(i) if return 0 => i,
-    Option::Some(_) => 42,
-    Option::None => -42,
-  }
-}
-
-fn bar() -> i32 {
-  if 12 == 12 && return 0 {
-    return 1;
-  } else {
-    return 2;
-  }
-}
-
-pub fn main() {
-  assert!(foo(Option::Some(123)) == 0);
-  assert!(foo(Option::None) == -42);
-  assert!(bar() == 0)
-}

--- a/stainless_frontend/tests/pass/return_stmt.rs
+++ b/stainless_frontend/tests/pass/return_stmt.rs
@@ -46,7 +46,7 @@ pub fn return_pattern_match(arg: u32) -> i32 {
   s
 }
 
-pub fn does_not_consume(option: &Option<i32>, v: i32) -> bool {
+pub fn some_option_fn(option: &Option<i32>, v: i32) -> bool {
   match option {
     Option::None => {}
     Option::Some(x) => return *x == v,
@@ -60,4 +60,27 @@ pub fn flatten<T>(opt: Option<Option<T>>) -> Option<T> {
     _ => {}
   }
   return Option::None;
+}
+
+#[allow(unused_variables)]
+fn foo(x: Option<i32>) -> i32 {
+  match x {
+    Option::Some(i) if return 0 => i,
+    Option::Some(_) => 42,
+    Option::None => -42,
+  }
+}
+
+fn bar() -> i32 {
+  if 12 == 12 && return 0 {
+    return 1;
+  } else {
+    return 2;
+  }
+}
+
+pub fn main() {
+  assert!(foo(Option::Some(123)) == 0);
+  assert!(foo(Option::None) == -42);
+  assert!(bar() == 0)
 }


### PR DESCRIPTION
- Add early return test case.
- Fix serialisation for markers larger than 255.
- Extract simple early return.

Closes #71.
