### PR TITLE
Fix cfg flag usage

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["--cfg", "stainless"]

--- a/libstainless_macros/src/implementation.rs
+++ b/libstainless_macros/src/implementation.rs
@@ -136,6 +136,7 @@ fn generate_fn_with_spec(fn_specs: FnSpecs) -> TokenStream {
     };
 
     parse_quote! {
+      #[cfg(stainless)]
       #[allow(unused)]
       #[clippy::stainless::#spec_type]
       |#fn_arg_tys#ret_param| -> #return_type {

--- a/libstainless_macros/src/lib.rs
+++ b/libstainless_macros/src/lib.rs
@@ -1,28 +1,29 @@
-mod implementation;
-mod spec;
-
-use spec::SpecType;
-
 use proc_macro::TokenStream;
+
+mod implementation;
+use implementation::*;
+
+mod spec;
+use spec::SpecType;
 
 /// Specs
 
-/// Precondition
-#[proc_macro_attribute]
-pub fn pre(attr: TokenStream, item: TokenStream) -> TokenStream {
-  specs(SpecType::Pre, attr, item)
+macro_rules! define_specs {
+  ($($spec:ident : $t:expr),*) => {
+    $(
+      #[proc_macro_attribute]
+      pub fn $spec(attr: TokenStream, item: TokenStream) -> TokenStream {
+        extract_specs_and_expand($t, attr.into(), item.into()).into()
+      }
+    )*
+  }
 }
 
-/// Postcondition
-#[proc_macro_attribute]
-pub fn post(attr: TokenStream, item: TokenStream) -> TokenStream {
-  specs(SpecType::Post, attr, item)
-}
-
-#[proc_macro_attribute]
-pub fn measure(attr: TokenStream, item: TokenStream) -> TokenStream {
-  specs(SpecType::Measure, attr, item)
-}
+define_specs!(
+  pre: SpecType::Pre,
+  post: SpecType::Post,
+  measure: SpecType::Measure
+);
 
 /// Flags
 
@@ -31,47 +32,10 @@ macro_rules! define_flags {
     $(
       #[proc_macro_attribute]
       pub fn $flag(attr: TokenStream, item: TokenStream) -> TokenStream {
-        flags(stringify!($flag), attr, item)
+        rewrite_flag(stringify!($flag), attr.into(), item.into()).into()
       }
     )*
   }
 }
 
 define_flags!(external, pure, mutable, var, law);
-
-#[cfg(stainless)]
-mod entry_point {
-  use super::*;
-  use implementation::*;
-
-  pub fn specs(
-    first_spec_type: SpecType,
-    first_attr_args: TokenStream,
-    item: TokenStream,
-  ) -> TokenStream {
-    extract_specs_and_expand(first_spec_type, first_attr_args.into(), item.into()).into()
-  }
-
-  pub fn flags(flag_name: &'static str, args: TokenStream, item: TokenStream) -> TokenStream {
-    rewrite_flag(flag_name, args.into(), item.into()).into()
-  }
-}
-
-#[cfg(not(stainless))]
-mod entry_point {
-  use super::*;
-
-  pub fn specs(
-    _first_spec_type: SpecType,
-    _first_attr_args: TokenStream,
-    item: TokenStream,
-  ) -> TokenStream {
-    item
-  }
-
-  pub fn flags(_flag_name: &'static str, _args: TokenStream, item: TokenStream) -> TokenStream {
-    item
-  }
-}
-
-use entry_point::*;

--- a/libstainless_macros/src/spec.rs
+++ b/libstainless_macros/src/spec.rs
@@ -16,7 +16,6 @@ pub enum SpecType {
 }
 
 impl SpecType {
-  #[cfg(stainless)]
   pub fn name(&self) -> &'static str {
     match self {
       SpecType::Pre => "pre",


### PR DESCRIPTION
Closes #114.

The `cfg(stainless)` did not work as desired previously, because it was evaluated at compilation
of the _macro crate_ instead of the compilation of the actual file to verify. This is solved 
by inlining the `cfg(stainless)` conditional code into the macro's output. The way the feature 
is set in `stainless_frontend` was inspired by [MIRAI](https://github.com/facebookexperimental/MIRAI/blob/master/checker/src/callbacks.rs).


- Correctly use cfg flag in macro's output.
- Beautify.
