### PR TITLE
Hack: extract clone for strings by erasure

### DIFF
--- a/stainless_extraction/src/std_items.rs
+++ b/stainless_extraction/src/std_items.rs
@@ -40,6 +40,7 @@ pub enum CrateItem {
   ToStringFn,
   StringType,
   PartialEqFn,
+  CloneFn,
 }
 
 use CrateItem::*;
@@ -62,6 +63,7 @@ impl CrateItem {
       ToStringFn => "std::string::ToString::to_string",
       StringType => "std::string::String",
       PartialEqFn => "std::cmp::PartialEq::eq",
+      CloneFn => "std::clone::Clone::clone",
     }
   }
 
@@ -71,7 +73,7 @@ impl CrateItem {
   pub fn crate_name(&self) -> &'static str {
     match self {
       BoxNewFn | ToStringFn | StringType => "alloc",
-      PhantomData | PartialEqFn => "core",
+      PhantomData | PartialEqFn | CloneFn => "core",
       _ => self.path().splitn(2, "::").next().unwrap(),
     }
   }

--- a/stainless_frontend/tests/extraction_tests.rs
+++ b/stainless_frontend/tests/extraction_tests.rs
@@ -99,6 +99,7 @@ define_tests!(
   pass: adts,
   pass: blocks,
   pass: boxes,
+  pass: clone_equality,
   pass: double_ref_param,
   pass: external_fn,
   pass: fact,

--- a/stainless_frontend/tests/pass/clone_equality.rs
+++ b/stainless_frontend/tests/pass/clone_equality.rs
@@ -1,0 +1,48 @@
+extern crate stainless;
+use stainless::*;
+
+trait EqualClone: Sized {
+  fn clone(&self) -> Self;
+
+  fn eq(&self, other: &Self) -> bool;
+
+  #[law]
+  fn preserve_equality(a: &Self, b: &Self) -> bool {
+    (a.eq(b) == a.clone().eq(b)) == (a.eq(&b.clone()) == a.clone().eq(&b.clone()))
+  }
+}
+
+pub struct Key(String);
+impl EqualClone for Key {
+  fn clone(&self) -> Self {
+    Key(self.0.clone())
+  }
+
+  fn eq(&self, other: &Self) -> bool {
+    self.0 == other.0
+  }
+}
+
+pub struct Door {
+  key_lock: Key,
+}
+
+impl Door {
+  fn try_open(&self, key: &Key) -> Result<(), &'static str> {
+    if key.eq(&self.key_lock) {
+      Ok(())
+    } else {
+      Err("can't open that door")
+    }
+  }
+}
+
+pub struct Person {
+  key: Key,
+}
+
+// If the person has the key of the door, it implies that they can open it.
+#[post(!(EqualClone::eq(&person.key, &door.key_lock)) || matches!(ret, Ok(output)))]
+pub fn main(door: Door, person: Person) -> Result<(), &'static str> {
+  door.try_open(&person.key.clone())
+}


### PR DESCRIPTION
In order to get any benefit of the special case that extracts `PartialEq::eq` on strings, this also needs to work across clones.
Especially, as in Rust one has to often clone a string explicitely.

The quick solution here achieves that goal by erasing calls to `std::clone::Clone::clone` for strings.
This is only safe as long as strings are not mutable, so it'll have to be revisited. Also, the real 
solution to the problem would be #39.


- Add test case for preserving equality with clones.
- Add std item for clone.
- Extract clone for strings by erasure.
