### PR TITLE
Make evidence parameters available in spec bodies

### DIFF
--- a/stainless_extraction/src/bindings.rs
+++ b/stainless_extraction/src/bindings.rs
@@ -155,7 +155,7 @@ impl<'l> DefContext<'l> {
   /// Adds a parameter to the available bindings.
   ///
   /// If the parameter is mutable, a new immutable parameter is inserted in the
-  /// paramter list. The binding with a LetVar from the new param to the
+  /// parameter list. The binding with a LetVar from the new param to the
   /// variable in the function's body needs to be created later with
   /// [BodyExtractor::wrap_body_let_vars].
   pub(super) fn add_param(

--- a/stainless_extraction/src/spec.rs
+++ b/stainless_extraction/src/spec.rs
@@ -110,9 +110,14 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
       }
 
       // Register all other bindings
-      for (vd, sid) in outer_fn_params.iter().zip(spec_param_ids) {
+      let (regular_params, ev_params) = outer_fn_params.split_at(spec_param_ids.len());
+      for (vd, sid) in regular_params.iter().zip(spec_param_ids) {
         bxtor.dcx.add_var(sid, vd.v);
       }
+      for e in ev_params {
+        bxtor.dcx.add_param(e, &mut bxtor.base);
+      }
+
       // Pick up any additional local bindings
       // (A spec neither has flags on the params, nor additional evidence params)
       bxtor.populate_def_context(&mut HashMap::new(), &[]);

--- a/stainless_frontend/tests/pass/clone_equality.rs
+++ b/stainless_frontend/tests/pass/clone_equality.rs
@@ -1,23 +1,27 @@
 extern crate stainless;
 use stainless::*;
 
-trait EqualClone: Sized {
-  fn clone(&self) -> Self;
-
+trait Equals {
   fn eq(&self, other: &Self) -> bool;
-
-  #[law]
-  fn preserve_equality(a: &Self, b: &Self) -> bool {
-    (a.eq(b) == a.clone().eq(b)) == (a.eq(&b.clone()) == a.clone().eq(&b.clone()))
-  }
 }
 
+trait Clone {
+  fn clone(&self) -> Self;
+}
+
+#[external]
+#[pure]
+#[post(x.clone().eq(&x))]
+#[allow(unused_variables)]
+fn clone_preserves_eq<T: Clone + Equals>(x: T) {}
+
 pub struct Key(String);
-impl EqualClone for Key {
+impl Clone for Key {
   fn clone(&self) -> Self {
     Key(self.0.clone())
   }
-
+}
+impl Equals for Key {
   fn eq(&self, other: &Self) -> bool {
     self.0 == other.0
   }
@@ -42,7 +46,7 @@ pub struct Person {
 }
 
 // If the person has the key of the door, it implies that they can open it.
-#[post(!(EqualClone::eq(&person.key, &door.key_lock)) || matches!(ret, Ok(output)))]
+#[post(!(Equals::eq(&person.key, &door.key_lock)) || matches!(ret, Ok(output)))]
 pub fn main(door: Door, person: Person) -> Result<(), &'static str> {
   door.try_open(&person.key.clone())
 }

--- a/stainless_frontend/tests/pass/clone_equality.rs
+++ b/stainless_frontend/tests/pass/clone_equality.rs
@@ -9,12 +9,6 @@ trait Clone {
   fn clone(&self) -> Self;
 }
 
-#[external]
-#[pure]
-#[post(x.clone().eq(&x))]
-#[allow(unused_variables)]
-fn clone_preserves_eq<T: Clone + Equals>(x: T) {}
-
 pub struct Key(String);
 impl Clone for Key {
   fn clone(&self) -> Self {

--- a/stainless_frontend/tests/pass/clone_equality.rs
+++ b/stainless_frontend/tests/pass/clone_equality.rs
@@ -46,7 +46,7 @@ pub struct Person {
 }
 
 // If the person has the key of the door, it implies that they can open it.
-#[post(!(Equals::eq(&person.key, &door.key_lock)) || matches!(ret, Ok(output)))]
+#[post(!(person.key.eq( &door.key_lock)) || matches!(ret, Ok(output)))]
 pub fn main(door: Door, person: Person) -> Result<(), &'static str> {
   door.try_open(&person.key.clone())
 }

--- a/stainless_frontend/tests/pass/type_class_call_specs.rs
+++ b/stainless_frontend/tests/pass/type_class_call_specs.rs
@@ -1,0 +1,16 @@
+extern crate stainless;
+use stainless::*;
+
+trait Equals {
+  fn eq(&self, other: &Self) -> bool;
+}
+
+trait Clone {
+  fn clone(&self) -> Self;
+}
+
+#[external]
+#[pure]
+#[post(x.clone().eq(&x))]
+#[allow(unused_variables)]
+fn clone_preserves_eq<T: Clone + Equals>(x: T) {}


### PR DESCRIPTION
Fixes the problem that evidence arguments added to the function's parameter list at extraction
were not available inside of spec bodies.﻿
