### PR TITLE
Erase all Clone calls & impls

### DIFF
--- a/stainless_extraction/src/expr/mod.rs
+++ b/stainless_extraction/src/expr/mod.rs
@@ -243,13 +243,13 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
 
   /// Extracts a call to `Clone::clone` by erasure.
   ///
-  /// FIXME: this is a quick-fix/hack to make use of `PartialEq::eq` for strings
-  ///   across clones, see [extract_partial_eq]. As soon, as strings can be mutated,
-  ///   this becomes potentially unsafe and has to be revisited.
-  ///   The way to correctly solve this use-case is by attaching a spec to the real
+  /// FIXME: This is a work-around for the problems encountered while extracting
+  ///   Clone and PartialEq as type classes. See the issue for details. The way
+  ///   to correctly solve this use-case is by attaching a spec to the real
   ///   `Clone::clone` that preserves equality.
+  ///   https://github.com/epfl-lara/rust-stainless/issues/136
   fn extract_clone(&mut self, expr: &'a Expr<'a, 'tcx>) -> Option<st::Expr<'l>> {
-    self.is_str_type(expr).then(|| self.extract_expr(expr))
+    Some(self.extract_expr(expr))
   }
 
   fn is_str_type(&mut self, expr: &'a Expr<'a, 'tcx>) -> bool {

--- a/stainless_extraction/src/std_items.rs
+++ b/stainless_extraction/src/std_items.rs
@@ -44,6 +44,7 @@ pub enum CrateItem {
   StringType,
   PartialEqFn,
   CloneFn,
+  CloneTrait,
   ImpliesFn,
   MapType,
   MapEmptyFn,
@@ -78,6 +79,7 @@ impl CrateItem {
       StringType => "std::string::String",
       PartialEqFn => "std::cmp::PartialEq::eq",
       CloneFn => "std::clone::Clone::clone",
+      CloneTrait => "std::clone::Clone",
       ImpliesFn => "stainless::Implies::implies",
       MapType => "stainless::Map",
       MapEmptyFn => "stainless::Map::<K, V>::empty",
@@ -97,7 +99,7 @@ impl CrateItem {
   pub fn crate_name(&self) -> &'static str {
     match self {
       BoxNewFn | ToStringFn | StringType => "alloc",
-      PhantomData | PartialEqFn | CloneFn | OptionType => "core",
+      PhantomData | PartialEqFn | CloneFn | CloneTrait | OptionType => "core",
       _ => self.path().splitn(2, "::").next().unwrap(),
     }
   }
@@ -106,6 +108,7 @@ impl CrateItem {
     match self {
       BeginPanicFmtFn => DefKind::Fn,
       SetType | MapType | StringType | PhantomData => DefKind::Struct,
+      CloneTrait => DefKind::Trait,
       OptionType => DefKind::Enum,
       _ => DefKind::AssocFn,
     }

--- a/stainless_frontend/tests/extraction_tests.rs
+++ b/stainless_frontend/tests/extraction_tests.rs
@@ -99,7 +99,7 @@ define_tests!(
   pass: adts,
   pass: blocks,
   pass: boxes,
-  pass: clone_equality,
+  pass: clone,
   pass: double_ref_param,
   pass: external_fn,
   pass: fact,

--- a/stainless_frontend/tests/pass/clone.rs
+++ b/stainless_frontend/tests/pass/clone.rs
@@ -1,33 +1,17 @@
 extern crate stainless;
 use stainless::*;
 
-trait Equals {
-  fn eq(&self, other: &Self) -> bool;
-}
-
-trait Clone {
-  fn clone(&self) -> Self;
-}
-
+#[derive(Clone)]
 pub struct Key(String);
-impl Clone for Key {
-  fn clone(&self) -> Self {
-    Key(self.0.clone())
-  }
-}
-impl Equals for Key {
-  fn eq(&self, other: &Self) -> bool {
-    self.0 == other.0
-  }
-}
 
+#[derive(Clone)]
 pub struct Door {
   key_lock: Key,
 }
 
 impl Door {
   fn try_open(&self, key: &Key) -> Result<(), &'static str> {
-    if key.eq(&self.key_lock) {
+    if key.0 == self.key_lock.0 {
       Ok(())
     } else {
       Err("can't open that door")
@@ -35,12 +19,17 @@ impl Door {
   }
 }
 
+#[derive(Clone)]
 pub struct Person {
   key: Key,
 }
 
+fn do_clone<T: Clone>(t: &T) -> T {
+  t.clone()
+}
+
 // If the person has the key of the door, it implies that they can open it.
-#[post(!(person.key.eq( &door.key_lock)) || matches!(ret, Ok(output)))]
+#[post((person.key.0 == door.key_lock.0).implies(matches!(ret, Ok(_))))]
 pub fn main(door: Door, person: Person) -> Result<(), &'static str> {
-  door.try_open(&person.key.clone())
+  door.try_open(&do_clone(&person.key))
 }


### PR DESCRIPTION
To clone a type in Rust, it must have an implementation of `std::clone::Clone`, which is usually derived from a macro. The derived implementation recursively clones the fields of a type. So, by default, the clone operation preserves equality. However, that is impossible for Stainless to understand because the behaviour is provided by two different type classes (`Clone` and `PartialEq`) that have no type or parameter dependency. 

As a first step to deal with the problem, this PR proposes to erase:
- all calls to `Clone::clone` with identity, and
- all `impl std::clone::Clone for X` blocks, because they are no longer called.

**To do**
- [x] Should also erase evidence arguments for Clone instances.

This allows progress on some benchmarks but is not sound in all cases. Details can be found in #136.
