### PR TITLE
Scope synth methods under common struct

### DIFF
--- a/stainless_extraction/src/expr/map.rs
+++ b/stainless_extraction/src/expr/map.rs
@@ -37,9 +37,9 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
       [key_tpe, val_tpe] => f
         .FiniteMap(
           vec![],
-          self.base.std_option_none(*val_tpe),
+          self.synth().std_option_none(*val_tpe),
           *key_tpe,
-          self.base.std_option_type(*val_tpe),
+          self.synth().std_option_type(*val_tpe),
         )
         .into(),
       _ => unreachable!(),
@@ -55,12 +55,12 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
   ) -> st::Expr<'l> {
     let f = self.factory();
     let val_tpe = self.base.extract_ty(substs.type_at(1), &self.txtcx, span);
-    let some_tpe = self.base.std_option_some_type(val_tpe);
+    let some_tpe = self.synth().std_option_some_type(val_tpe);
     f.Assert(
       f.IsInstanceOf(f.MapApply(map, key).into(), some_tpe).into(),
       Some("Map undefined at this index".into()),
       self
-        .base
+        .synth()
         .std_option_some_value(f.AsInstanceOf(f.MapApply(map, key).into(), some_tpe).into()),
     )
     .into()
@@ -78,7 +78,7 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
     f.Not(
       f.Equals(
         f.MapApply(map, key).into(),
-        self.base.std_option_none(val_tpe),
+        self.synth().std_option_none(val_tpe),
       )
       .into(),
     )
@@ -95,7 +95,7 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
     let val_tpe = self.base.extract_ty(substs.type_at(1), &self.txtcx, span);
     self
       .factory()
-      .MapUpdated(map, key, self.base.std_option_none(val_tpe))
+      .MapUpdated(map, key, self.synth().std_option_none(val_tpe))
       .into()
   }
 
@@ -109,7 +109,7 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
   ) -> st::Expr<'l> {
     let f = self.factory();
     let val_tpe = self.base.extract_ty(substs.type_at(1), &self.txtcx, span);
-    f.MapUpdated(map, key, self.base.std_option_some(val, val_tpe))
+    f.MapUpdated(map, key, self.synth().std_option_some(val, val_tpe))
       .into()
   }
 
@@ -123,11 +123,11 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
   ) -> st::Expr<'l> {
     let f = self.factory();
     let val_tpe = self.base.extract_ty(substs.type_at(1), &self.txtcx, span);
-    let some_tpe = self.base.std_option_some_type(val_tpe);
+    let some_tpe = self.synth().std_option_some_type(val_tpe);
     f.IfExpr(
       f.IsInstanceOf(f.MapApply(map, key).into(), some_tpe).into(),
       self
-        .base
+        .synth()
         .std_option_some_value(f.AsInstanceOf(f.MapApply(map, key).into(), some_tpe).into()),
       or_else,
     )

--- a/stainless_extraction/src/lib.rs
+++ b/stainless_extraction/src/lib.rs
@@ -43,6 +43,7 @@ mod flags;
 mod fns;
 mod krate;
 mod std_items;
+mod synth;
 mod ty;
 mod utils;
 

--- a/stainless_extraction/src/std_items.rs
+++ b/stainless_extraction/src/std_items.rs
@@ -240,6 +240,12 @@ impl StdItems {
     self.def_to_item.get(&def_id).copied()
   }
 
+  #[inline]
+  pub(super) fn item_to_def(&self, item: StdItem) -> DefId {
+    // By construction, we know that all items are in the map.
+    self.item_to_def.get(&item).copied().unwrap()
+  }
+
   pub(super) fn is_sized_trait(&self, def_id: DefId) -> bool {
     self
       .def_to_item_opt(def_id)
@@ -254,59 +260,5 @@ impl StdItems {
         | Some(StdItem::LangItem(LangItem::FnMutTrait))
         | Some(StdItem::LangItem(LangItem::FnOnceTrait))
     )
-  }
-}
-
-/// Synthetisation of std::option::Option trees in Stainless AST.
-impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
-  pub(super) fn std_option_type(&mut self, tpe: st::Type<'l>) -> st::Type<'l> {
-    self
-      .factory()
-      .ADTType(self.option_adt().id, vec![tpe])
-      .into()
-  }
-
-  pub(super) fn std_option_none(&mut self, tpe: st::Type<'l>) -> st::Expr<'l> {
-    self.factory().ADT(self.none_id(), vec![tpe], vec![]).into()
-  }
-
-  pub(super) fn std_option_some(&mut self, val: st::Expr<'l>, tpe: st::Type<'l>) -> st::Expr<'l> {
-    self
-      .factory()
-      .ADT(self.some_id(), vec![tpe], vec![val])
-      .into()
-  }
-
-  pub(super) fn std_option_some_type(&mut self, tpe: st::Type<'l>) -> st::Type<'l> {
-    self.factory().ADTType(self.some_id(), vec![tpe]).into()
-  }
-
-  pub(super) fn std_option_some_value(&mut self, some: st::Expr<'l>) -> st::Expr<'l> {
-    self
-      .factory()
-      .ClassSelector(some, self.some_value_id())
-      .into()
-  }
-
-  fn option_adt(&mut self) -> &'l st::ADTSort<'l> {
-    let def_id = self
-      .std_items
-      .item_to_def
-      .get(&StdItem::CrateItem(OptionType))
-      .copied()
-      .unwrap();
-    self.get_or_extract_adt(def_id)
-  }
-
-  fn none_id(&mut self) -> StainlessSymId<'l> {
-    self.option_adt().constructors[0].id
-  }
-
-  fn some_id(&mut self) -> StainlessSymId<'l> {
-    self.option_adt().constructors[1].id
-  }
-
-  fn some_value_id(&mut self) -> StainlessSymId<'l> {
-    self.option_adt().constructors[1].fields[0].v.id
   }
 }

--- a/stainless_extraction/src/synth.rs
+++ b/stainless_extraction/src/synth.rs
@@ -1,0 +1,73 @@
+use super::*;
+
+pub struct Synth<'a, 'l, 'tcx> {
+  base: &'a mut BaseExtractor<'l, 'tcx>,
+}
+
+impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
+  pub fn synth<'a>(&'a mut self) -> Synth<'a, 'l, 'tcx> {
+    Synth { base: self }
+  }
+}
+
+impl<'b, 'l, 'tcx> BodyExtractor<'b, 'l, 'tcx> {
+  pub fn synth<'a>(&'a mut self) -> Synth<'a, 'l, 'tcx> {
+    self.base.synth()
+  }
+}
+
+/// Synthetisation of std::option::Option trees in Stainless AST.
+impl<'a, 'l, 'tcx> Synth<'a, 'l, 'tcx> {
+  pub(super) fn std_option_type(&mut self, tpe: st::Type<'l>) -> st::Type<'l> {
+    self
+      .factory()
+      .ADTType(self.option_adt().id, vec![tpe])
+      .into()
+  }
+
+  pub(super) fn std_option_none(&mut self, tpe: st::Type<'l>) -> st::Expr<'l> {
+    self.factory().ADT(self.none_id(), vec![tpe], vec![]).into()
+  }
+
+  pub(super) fn std_option_some(&mut self, val: st::Expr<'l>, tpe: st::Type<'l>) -> st::Expr<'l> {
+    self
+      .factory()
+      .ADT(self.some_id(), vec![tpe], vec![val])
+      .into()
+  }
+
+  pub(super) fn std_option_some_type(&mut self, tpe: st::Type<'l>) -> st::Type<'l> {
+    self.factory().ADTType(self.some_id(), vec![tpe]).into()
+  }
+
+  pub(super) fn std_option_some_value(&mut self, some: st::Expr<'l>) -> st::Expr<'l> {
+    self
+      .factory()
+      .ClassSelector(some, self.some_value_id())
+      .into()
+  }
+
+  fn option_adt(&mut self) -> &'l st::ADTSort<'l> {
+    let def_id = self
+      .base
+      .std_items
+      .item_to_def(StdItem::CrateItem(CrateItem::OptionType));
+    self.base.get_or_extract_adt(def_id)
+  }
+
+  fn none_id(&mut self) -> StainlessSymId<'l> {
+    self.option_adt().constructors[0].id
+  }
+
+  fn some_id(&mut self) -> StainlessSymId<'l> {
+    self.option_adt().constructors[1].id
+  }
+
+  fn some_value_id(&mut self) -> StainlessSymId<'l> {
+    self.option_adt().constructors[1].fields[0].v.id
+  }
+
+  fn factory(&self) -> &'l st::Factory {
+    self.base.factory()
+  }
+}

--- a/stainless_extraction/src/synth.rs
+++ b/stainless_extraction/src/synth.rs
@@ -1,16 +1,23 @@
 use super::*;
 
+/// This is just a proxy, a mutable reference to the base extractor. The idea of
+/// `Synth` is just to scope some methods under a common namespace, therefore
+/// the struct mainly provides a namespace/scope.
 pub struct Synth<'a, 'l, 'tcx> {
   base: &'a mut BaseExtractor<'l, 'tcx>,
 }
 
 impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
+  /// Returns a `Synth` which provides access to all methods that synthesise
+  /// items/trees.
   pub fn synth<'a>(&'a mut self) -> Synth<'a, 'l, 'tcx> {
     Synth { base: self }
   }
 }
 
 impl<'b, 'l, 'tcx> BodyExtractor<'b, 'l, 'tcx> {
+  /// Returns a `Synth` which provides access to all methods that synthesise
+  /// items/trees.
   pub fn synth<'a>(&'a mut self) -> Synth<'a, 'l, 'tcx> {
     self.base.synth()
   }

--- a/stainless_extraction/src/ty.rs
+++ b/stainless_extraction/src/ty.rs
@@ -118,7 +118,9 @@ impl<'l, 'tcx> BaseExtractor<'l, 'tcx> {
         Some(StdItem::CrateItem(CrateItem::MapType)) => {
           let arg_tps = self.extract_tys(substitutions.types(), txtcx, span);
           match &arg_tps[..] {
-            [key_tpe, val_tpe] => f.MapType(*key_tpe, self.std_option_type(*val_tpe)).into(),
+            [key_tpe, val_tpe] => f
+              .MapType(*key_tpe, self.synth().std_option_type(*val_tpe))
+              .into(),
             _ => {
               self.unsupported(
                 span,


### PR DESCRIPTION
Just adds a namespace, as discussed in #127, resolves the last drawback.

- Scope synthesising methods in own module/struct.
- Add some doc.
