### PR TITLE
Rename stainless collection API to match Rust std

### DIFF
--- a/libstainless/src/map.rs
+++ b/libstainless/src/map.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::new_without_default, clippy::should_implement_trait)]
+
 use im::HashMap;
 use std::hash::Hash;
 

--- a/libstainless/src/map.rs
+++ b/libstainless/src/map.rs
@@ -11,7 +11,7 @@ where
   K: Eq + Hash + Clone,
   V: Clone,
 {
-  pub fn empty() -> Self {
+  pub fn new() -> Self {
     Self {
       map: HashMap::new(),
     }
@@ -21,26 +21,26 @@ where
     self.map.get(key)
   }
 
-  pub fn get_or_else<'a>(&'a self, key: &K, elze: &'a V) -> &'a V {
+  pub fn get_or<'a>(&'a self, key: &K, elze: &'a V) -> &'a V {
     self.get(key).unwrap_or(elze)
   }
 
   /// Panics if the key is not in the map.
-  pub fn apply(&self, key: &K) -> &V {
+  pub fn index(&self, key: &K) -> &V {
     self.get(key).unwrap()
   }
 
-  pub fn contains(&self, key: &K) -> bool {
+  pub fn contains_key(&self, key: &K) -> bool {
     self.map.contains_key(key)
   }
 
-  pub fn updated(&self, key: K, val: V) -> Self {
+  pub fn insert(&self, key: K, val: V) -> Self {
     Self {
       map: self.map.update(key, val),
     }
   }
 
-  pub fn removed(&self, key: &K) -> Self {
+  pub fn remove(&self, key: &K) -> Self {
     Self {
       map: self.map.without(key),
     }
@@ -53,33 +53,33 @@ mod test {
 
   #[test]
   fn test_empty() {
-    assert!(!Map::<_, bool>::empty().contains(&123));
-    assert_eq!(Map::<_, u8>::empty().get(&456), None);
-    assert_eq!(Map::empty().get_or_else(&789, &0), &0);
+    assert!(!Map::<_, bool>::new().contains_key(&123));
+    assert_eq!(Map::<_, u8>::new().get(&456), None);
+    assert_eq!(Map::new().get_or(&789, &0), &0);
   }
 
   #[test]
   fn test_get_removed() {
-    let map: Map<String, i32> = Map::empty()
-      .updated("foo".into(), 1)
-      .updated("bar".into(), 2)
-      .updated("baz".into(), 3);
+    let map: Map<String, i32> = Map::new()
+      .insert("foo".into(), 1)
+      .insert("bar".into(), 2)
+      .insert("baz".into(), 3);
 
     assert_eq!(Some(&1), map.get(&"foo".into()));
-    let map = map.removed(&"foo".into());
-    assert!(!map.contains(&"foo".into()));
+    let map = map.remove(&"foo".into());
+    assert!(!map.contains_key(&"foo".into()));
 
-    assert_eq!(&3, map.apply(&"baz".into()));
-    let map = map.updated("bar".into(), 8);
-    assert_eq!(&8, map.apply(&"bar".into()));
+    assert_eq!(&3, map.index(&"baz".into()));
+    let map = map.insert("bar".into(), 8);
+    assert_eq!(&8, map.index(&"bar".into()));
   }
 
   #[test]
   fn test_get_or_else() {
-    assert_eq!(Map::empty().get_or_else(&1, &0), &0);
+    assert_eq!(Map::new().get_or(&1, &0), &0);
 
-    let m1 = Map::empty().updated(1, 123);
-    assert_eq!(m1.get_or_else(&1, &0), &123);
-    assert_eq!(m1.get_or_else(&0, &-1), &-1);
+    let m1 = Map::new().insert(1, 123);
+    assert_eq!(m1.get_or(&1, &0), &123);
+    assert_eq!(m1.get_or(&0, &-1), &-1);
   }
 }

--- a/libstainless/src/set.rs
+++ b/libstainless/src/set.rs
@@ -10,7 +10,7 @@ impl<T> Set<T>
 where
   T: Eq + Hash + Clone,
 {
-  pub fn empty() -> Self {
+  pub fn new() -> Self {
     Self {
       set: HashSet::new(),
     }
@@ -21,7 +21,7 @@ where
     }
   }
 
-  pub fn add(&self, t: T) -> Self {
+  pub fn insert(&self, t: T) -> Self {
     Self {
       set: self.set.update(t),
     }
@@ -49,7 +49,7 @@ where
     }
   }
 
-  pub fn is_subset_of(&self, other: &Set<T>) -> bool {
+  pub fn is_subset(&self, other: &Set<T>) -> bool {
     self.set.is_subset(&other.set)
   }
 }
@@ -60,30 +60,30 @@ mod test {
 
   #[test]
   fn test_empty() {
-    assert!(!Set::empty().contains(&123));
-    assert!(Set::<i32>::empty().is_subset_of(&Set::empty()));
-    assert!(Set::empty().is_subset_of(&Set::singleton(123)));
+    assert!(!Set::new().contains(&123));
+    assert!(Set::<i32>::new().is_subset(&Set::new()));
+    assert!(Set::new().is_subset(&Set::singleton(123)));
   }
 
   #[test]
   fn test_set_theory() {
-    let s1 = Set::singleton(1).add(2).add(3);
-    let s2 = Set::singleton(1).add(2);
-    let s3 = Set::singleton(3).add(4);
+    let s1 = Set::singleton(1).insert(2).insert(3);
+    let s2 = Set::singleton(1).insert(2);
+    let s3 = Set::singleton(3).insert(4);
 
-    assert!(!s1.is_subset_of(&s2));
-    assert!(!s1.is_subset_of(&s3));
-    assert!(s2.is_subset_of(&s1));
-    assert!(!s3.is_subset_of(&s1));
+    assert!(!s1.is_subset(&s2));
+    assert!(!s1.is_subset(&s3));
+    assert!(s2.is_subset(&s1));
+    assert!(!s3.is_subset(&s1));
 
     let new = s1.union(s3.clone()).difference(s2.clone());
-    assert!(new.is_subset_of(&s3) && s3.is_subset_of(&new));
-    assert!(s2.intersection(s3).is_subset_of(&Set::empty()))
+    assert!(new.is_subset(&s3) && s3.is_subset(&new));
+    assert!(s2.intersection(s3).is_subset(&Set::new()))
   }
 
   #[test]
   fn test_remove_contains() {
-    let set: Set<String> = Set::singleton("foo".into()).add("bar".into());
+    let set: Set<String> = Set::singleton("foo".into()).insert("bar".into());
     let set = set.difference(Set::singleton("bar".into()));
     assert!(!set.contains(&"bar".into()));
     let set = set.difference(Set::singleton("foo".into()));

--- a/libstainless/src/set.rs
+++ b/libstainless/src/set.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::new_without_default)]
+
 use im::HashSet;
 use std::hash::Hash;
 

--- a/stainless_extraction/src/expr/map.rs
+++ b/stainless_extraction/src/expr/map.rs
@@ -9,16 +9,16 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
     span: Span,
   ) -> st::Expr<'l> {
     match (item, &self.extract_exprs(args)[..]) {
-      (MapEmptyFn, []) => self.extract_map_creation(substs_ref, span),
+      (MapNewFn, []) => self.extract_map_creation(substs_ref, span),
 
-      (MapApplyFn, [map, key]) => self.extract_map_apply(*map, *key, substs_ref, span),
-      (MapContainsFn, [map, key]) => self.extract_map_contains(*map, *key, substs_ref, span),
-      (MapRemovedFn, [map, key]) => self.extract_map_removed(*map, *key, substs_ref, span),
+      (MapIndexFn, [map, key]) => self.extract_map_apply(*map, *key, substs_ref, span),
+      (MapContainsKeyFn, [map, key]) => self.extract_map_contains(*map, *key, substs_ref, span),
+      (MapRemoveFn, [map, key]) => self.extract_map_removed(*map, *key, substs_ref, span),
       (MapGetFn, [map, key]) => self.factory().MapApply(*map, *key).into(),
-      (MapUpdatedFn, [map, key, val]) => {
+      (MapInsertFn, [map, key, val]) => {
         self.extract_map_updated(*map, *key, *val, substs_ref, span)
       }
-      (MapGetOrElseFn, [map, key, or_else]) => {
+      (MapGetOrFn, [map, key, or_else]) => {
         self.extract_map_get_or_else(*map, *key, *or_else, substs_ref, span)
       }
 

--- a/stainless_extraction/src/expr/set.rs
+++ b/stainless_extraction/src/expr/set.rs
@@ -9,7 +9,7 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
     span: Span,
   ) -> st::Expr<'l> {
     match item {
-      SetEmptyFn | SetSingletonFn => self.extract_set_creation(args, substs_ref, span),
+      SetNewFn | SetSingletonFn => self.extract_set_creation(args, substs_ref, span),
       i if i.is_set_related() => self.extract_set_op(i, args, span),
       _ => panic!("Cannot be called on non set-related item, was {:?}", item),
     }
@@ -24,11 +24,11 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
     let f = self.factory();
     match &self.extract_exprs(args)[..] {
       [set, arg] => match std_item {
-        SetAddFn => f.SetAdd(*set, *arg).into(),
+        SetInsertFn => f.SetAdd(*set, *arg).into(),
         SetDifferenceFn => f.SetDifference(*set, *arg).into(),
         SetIntersectionFn => f.SetIntersection(*set, *arg).into(),
         SetUnionFn => f.SetUnion(*set, *arg).into(),
-        SubsetOfFn => f.SubsetOf(*set, *arg).into(),
+        SetSubsetFn => f.SubsetOf(*set, *arg).into(),
         SetContainsFn => f.ElementOfSet(*arg, *set).into(),
         _ => unreachable!(),
       },

--- a/stainless_extraction/src/std_items.rs
+++ b/stainless_extraction/src/std_items.rs
@@ -30,13 +30,13 @@ pub enum LangItem {
 pub enum CrateItem {
   BeginPanicFmtFn,
   SetType,
-  SetAddFn,
+  SetInsertFn,
   SetContainsFn,
   SetDifferenceFn,
   SetIntersectionFn,
   SetUnionFn,
-  SubsetOfFn,
-  SetEmptyFn,
+  SetSubsetFn,
+  SetNewFn,
   SetSingletonFn,
   BoxNewFn,
   PhantomData,
@@ -47,13 +47,13 @@ pub enum CrateItem {
   CloneTrait,
   ImpliesFn,
   MapType,
-  MapEmptyFn,
-  MapApplyFn,
+  MapNewFn,
+  MapIndexFn,
   MapGetFn,
-  MapGetOrElseFn,
-  MapContainsFn,
-  MapUpdatedFn,
-  MapRemovedFn,
+  MapGetOrFn,
+  MapContainsKeyFn,
+  MapInsertFn,
+  MapRemoveFn,
   OptionType,
 }
 
@@ -65,13 +65,13 @@ impl CrateItem {
     match self {
       BeginPanicFmtFn => "std::rt::begin_panic_fmt",
       SetType => "stainless::Set",
-      SetAddFn => "stainless::Set::<T>::add",
+      SetInsertFn => "stainless::Set::<T>::insert",
       SetContainsFn => "stainless::Set::<T>::contains",
       SetDifferenceFn => "stainless::Set::<T>::difference",
       SetIntersectionFn => "stainless::Set::<T>::intersection",
       SetUnionFn => "stainless::Set::<T>::union",
-      SubsetOfFn => "stainless::Set::<T>::is_subset_of",
-      SetEmptyFn => "stainless::Set::<T>::empty",
+      SetSubsetFn => "stainless::Set::<T>::is_subset",
+      SetNewFn => "stainless::Set::<T>::new",
       SetSingletonFn => "stainless::Set::<T>::singleton",
       BoxNewFn => "std::boxed::Box::<T>::new",
       PhantomData => "std::marker::PhantomData",
@@ -82,13 +82,13 @@ impl CrateItem {
       CloneTrait => "std::clone::Clone",
       ImpliesFn => "stainless::Implies::implies",
       MapType => "stainless::Map",
-      MapEmptyFn => "stainless::Map::<K, V>::empty",
-      MapApplyFn => "stainless::Map::<K, V>::apply",
+      MapNewFn => "stainless::Map::<K, V>::new",
+      MapIndexFn => "stainless::Map::<K, V>::index",
       MapGetFn => "stainless::Map::<K, V>::get",
-      MapGetOrElseFn => "stainless::Map::<K, V>::get_or_else",
-      MapContainsFn => "stainless::Map::<K, V>::contains",
-      MapUpdatedFn => "stainless::Map::<K, V>::updated",
-      MapRemovedFn => "stainless::Map::<K, V>::removed",
+      MapGetOrFn => "stainless::Map::<K, V>::get_or",
+      MapContainsKeyFn => "stainless::Map::<K, V>::contains_key",
+      MapInsertFn => "stainless::Map::<K, V>::insert",
+      MapRemoveFn => "stainless::Map::<K, V>::remove",
       OptionType => "std::option::Option",
     }
   }
@@ -118,14 +118,14 @@ impl CrateItem {
     matches!(
       self,
       SetType
-        | SetEmptyFn
+        | SetNewFn
         | SetSingletonFn
-        | SetAddFn
+        | SetInsertFn
         | SetContainsFn
         | SetDifferenceFn
         | SetIntersectionFn
         | SetUnionFn
-        | SubsetOfFn
+        | SetSubsetFn
     )
   }
 
@@ -133,13 +133,13 @@ impl CrateItem {
     matches!(
       self,
       MapType
-        | MapEmptyFn
-        | MapApplyFn
-        | MapContainsFn
+        | MapNewFn
+        | MapIndexFn
+        | MapContainsKeyFn
         | MapGetFn
-        | MapGetOrElseFn
-        | MapUpdatedFn
-        | MapRemovedFn
+        | MapGetOrFn
+        | MapInsertFn
+        | MapRemoveFn
     )
   }
 }

--- a/stainless_frontend/tests/pass/insertion_sort.rs
+++ b/stainless_frontend/tests/pass/insertion_sort.rs
@@ -30,8 +30,8 @@ impl List<i32> {
   #[measure(self)]
   pub fn contents(&self) -> Set<i32> {
     match self {
-      List::Nil => Set::empty(),
-      List::Cons(head, tail) => tail.contents().add(*head),
+      List::Nil => Set::new(),
+      List::Cons(head, tail) => tail.contents().insert(*head),
     }
   }
 
@@ -69,8 +69,8 @@ impl List<i32> {
   #[post(
     ret.size() == self.size() + 1 &&
     ret.is_sorted() &&
-    ret.contents().is_subset_of(&self.contents().add(e)) &&
-    self.contents().add(e).is_subset_of(&ret.contents())
+    ret.contents().is_subset(&self.contents().insert(e)) &&
+    self.contents().insert(e).is_subset(&ret.contents())
   )]
   pub fn sorted_insert(self, e: i32) -> List<i32> {
     match self {
@@ -85,8 +85,8 @@ impl List<i32> {
   #[post(
     ret.size() == self.size() &&
     ret.is_sorted() &&
-    ret.contents().is_subset_of(&self.contents()) &&
-    self.contents().is_subset_of(&ret.contents())
+    ret.contents().is_subset(&self.contents()) &&
+    self.contents().is_subset(&ret.contents())
   )]
   pub fn sort(self) -> List<i32> {
     match self {

--- a/stainless_frontend/tests/pass/map_ops.rs
+++ b/stainless_frontend/tests/pass/map_ops.rs
@@ -3,35 +3,35 @@ use stainless::*;
 
 /// This test is equivalent to the Scala benchmark:
 /// https://github.com/epfl-lara/stainless/blob/master/frontends/benchmarks/verification/valid/MapDiff.scala
-#[pre(m.contains(&1) && m.contains(&2) && m.contains(&3))]
+#[pre(m.contains_key(&1) && m.contains_key(&2) && m.contains_key(&3))]
 pub fn test(m: &Map<u32, u32>) {
-  let m2 = m.removed(&1).removed(&2);
-  assert!(!m2.contains(&1));
-  assert!(!m2.contains(&2));
-  assert!(m2.contains(&3));
+  let m2 = m.remove(&1).remove(&2);
+  assert!(!m2.contains_key(&1));
+  assert!(!m2.contains_key(&2));
+  assert!(m2.contains_key(&3));
   // Deref to do primitive equality of ints
-  assert!(*m2.apply(&3) == *m.apply(&3))
+  assert!(*m2.index(&3) == *m.index(&3))
 }
 
-#[pre(!a.contains(&0))]
+#[pre(!a.contains_key(&0))]
 #[post(ret)]
 pub fn test1(a: &Map<u32, u32>) -> bool {
-  let b = a.updated(0, 1);
-  let c = a.updated(0, 1);
+  let b = a.insert(0, 1);
+  let c = a.insert(0, 1);
   // Deref to do primitive equality of ints
-  *b.apply(&0) == *c.apply(&0)
+  *b.index(&0) == *c.index(&0)
 }
 
-#[pre(!a.contains(&0))]
+#[pre(!a.contains_key(&0))]
 #[post(ret == -123)]
 pub fn test3(a: &Map<u32, i32>) -> i32 {
-  let b = *a.get_or_else(&0, &-123);
+  let b = *a.get_or(&0, &-123);
   // Deref to do primitive equality of ints
-  assert!(b == *Map::empty().get_or_else(&0, &-123));
+  assert!(b == *Map::new().get_or(&0, &-123));
   b
 }
 
-#[pre(!a.contains(&0))]
+#[pre(!a.contains_key(&0))]
 #[post(matches!(ret, None))]
 pub fn test2(a: &Map<u32, u32>) -> Option<&u32> {
   a.get(&0)

--- a/stainless_frontend/tests/pass/set_ops.rs
+++ b/stainless_frontend/tests/pass/set_ops.rs
@@ -6,13 +6,13 @@ use stainless::*;
 
 #[post(ret)]
 pub fn set1() -> bool {
-  let s = Set::singleton(1).add(2).add(3).add(4);
+  let s = Set::singleton(1).insert(2).insert(3).insert(4);
   s.contains(&3)
 }
 
 #[post(ret)]
 pub fn set2() -> bool {
-  let s1 = Set::empty().add(1);
+  let s1 = Set::new().insert(1);
   let s2 = Set::singleton(1);
-  s1.is_subset_of(&s2) && s2.is_subset_of(&s1)
+  s1.is_subset(&s2) && s2.is_subset(&s1)
 }


### PR DESCRIPTION
Closes #144.

All methods that have the same signature as those in `std::collections` now also have the same name. Some methods like `insert` and `remove` don't have the same return type (because Stainless collections return the newly created collection – they're immutable) but the names are now closer to `std`.

For the Scala `getOrElse` and `apply` there are no direct equivalents. However, as `std::collection` can be indexed, the `apply` was named `index`. `getOrElse` was named `get_or` in analogy of `unwrap_or` from `std::option::Option`.﻿
