### PR TITLE
Allow local modules and imports

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,3 +79,5 @@ jobs:
 
       - name: Build & run cargo stainless on demo
         run: cd demo && cargo build && cargo stainless
+        env:
+          STAINLESS_HOME: ${{ github.workspace }}/stainless-noxt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,3 +70,12 @@ jobs:
           STAINLESS_HOME: ${{ github.workspace }}/stainless-noxt
         with:
           command: test
+
+      - name: Run cargo install
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --path stainless_frontend
+
+      - name: Run cargo stainless on demo
+        run: cd demo && cargo stainless

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,5 +77,5 @@ jobs:
           command: install
           args: --path stainless_frontend
 
-      - name: Run cargo stainless on demo
-        run: cd demo && cargo stainless
+      - name: Build & run cargo stainless on demo
+        run: cd demo && cargo build && cargo stainless

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -2,5 +2,5 @@
 name = "demo"
 version = "0.0.1"
 
-[dev-dependencies]
+[dependencies]
 stainless = { path = "../libstainless" }

--- a/demo/lib.rs
+++ b/demo/lib.rs
@@ -1,1 +1,0 @@
-// This file is intentionally left blank.

--- a/demo/src/list.rs
+++ b/demo/src/list.rs
@@ -1,0 +1,33 @@
+use super::*;
+
+pub enum List<T> {
+  Nil,
+  Cons(T, Box<List<T>>),
+}
+
+impl List<u32> {
+  #[measure(self)]
+  pub fn contains(&self, t: &u32) -> bool {
+    match self {
+      List::Nil => false,
+      List::Cons(head, tail) => *head == *t || tail.contains(t),
+    }
+  }
+
+  #[post(!ret.contains(t))]
+  pub fn remove(self, t: &u32) -> Self {
+    match self {
+      List::Nil => List::Nil,
+      List::Cons(head, tail) if head == *t => tail.remove(t),
+      List::Cons(head, tail) => List::Cons(head, Box::new(tail.remove(t))),
+    }
+  }
+
+  #[post(ret.contains(&t))]
+  pub fn insert(self, t: u32) -> Self {
+    match self {
+      List::Nil => List::Cons(t, Box::new(List::Nil)),
+      _ => List::Cons(t, Box::new(self)),
+    }
+  }
+}

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -1,0 +1,16 @@
+//! This demo project showcases the use of different modules. For more examples,
+//! see `../examples` or `../../stainless_frontend/tests/pass`.
+
+extern crate stainless;
+use stainless::*;
+
+mod list;
+use list::*;
+
+pub fn main() {
+  let list = List::Cons(123, Box::new(List::Nil));
+  let list = list.insert(456);
+  assert!(list.contains(&456));
+  let list = list.remove(&123);
+  assert!(!list.contains(&123));
+}

--- a/stainless_frontend/tests/extraction_tests.rs
+++ b/stainless_frontend/tests/extraction_tests.rs
@@ -135,6 +135,7 @@ define_tests!(
   pass: type_class_multi_lookup,
   pass: type_class_specs,
   pass: type_class_without_evidence,
+  pass: use_local,
   pass: use_std,
   pass: strings,
   fail_verification: box_as_ref,

--- a/stainless_frontend/tests/pass/use_local.rs
+++ b/stainless_frontend/tests/pass/use_local.rs
@@ -1,0 +1,19 @@
+#![allow(unused_imports, unused_variables, dead_code)]
+
+extern crate stainless;
+
+mod use_std;
+use use_std::*;
+
+mod fact;
+use fact::fact;
+
+mod int_option;
+use int_option::IntOption;
+
+pub fn main() {
+  let opt = IntOption::Some(5);
+
+  foo();
+  assert!(fact(3) == 6);
+}

--- a/stainless_frontend/tests/pass/use_std.rs
+++ b/stainless_frontend/tests/pass/use_std.rs
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use std::prelude::v1::*;
 
+use std::hash::Hash;
+
 extern crate stainless;
 
-pub fn main() {}
+pub fn foo() {}


### PR DESCRIPTION
Closes #146.

All `use` statements are now allowed but a warning is emitted for "unknown" ones.
E.g. the `stainless` crate, crate-local module imports and some things from `std` are ignored, all others
get the following warning:

```
warning: Unknown use statement. Stainless likely cannot deal with the imported items.
 --> src/file.rs:1:1
  |
1 | use std::collection::HashMap;
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

- Create test cases.
- Allow local use, mod. Warn for external use.
