### PR TITLE
Fix matching on empty tuples (Unit)

### DIFF
--- a/stainless_extraction/src/expr/pattern.rs
+++ b/stainless_extraction/src/expr/pattern.rs
@@ -151,6 +151,11 @@ impl<'a, 'l, 'tcx> BodyExtractor<'a, 'l, 'tcx> {
           )
           .into(),
 
+        // Empty tuple is more like Unit
+        TyKind::Tuple(substs) if substs.is_empty() => {
+          f.LiteralPattern(binder, f.UnitLiteral().into()).into()
+        }
+
         TyKind::Tuple(substs) => {
           let id = self.synth().tuple_id(substs.len());
           self

--- a/stainless_frontend/tests/extraction_tests.rs
+++ b/stainless_frontend/tests/extraction_tests.rs
@@ -130,6 +130,7 @@ define_tests!(
   pass: trait_bounds,
   pass: struct_update,
   pass: tuple_match,
+  pass: tuple_result,
   pass: tuples,
   pass: type_class,
   pass: type_class_multi_lookup,

--- a/stainless_frontend/tests/pass/tuple_result.rs
+++ b/stainless_frontend/tests/pass/tuple_result.rs
@@ -1,0 +1,9 @@
+extern crate stainless;
+
+pub fn main() {
+  let a: Result<(), i32> = Ok(());
+  let b: Result<(), i32> = Err(123);
+
+  assert!(matches!(a, Ok(())));
+  assert!(matches!(b, Err(123)))
+}


### PR DESCRIPTION
In `rustc` empty tuples and units are the same when pattern matching, this needed to be fixed for Stainless.

