### PR TITLE
Turn measure inference back on

### DIFF
--- a/stainless_backend/src/lib.rs
+++ b/stainless_backend/src/lib.rs
@@ -57,8 +57,6 @@ impl Backend {
       .arg("--batched")
       .arg("--vc-cache=false")
       .arg("--type-checker=false")
-      .arg("--check-measures=false")
-      .arg("--infer-measures=false")
       .arg(format!("--timeout={}", config.timeout))
       .arg(format!("--print-ids={}", config.print_ids))
       .arg(format!("--print-types={}", config.print_types))


### PR DESCRIPTION
Turned off somewhere around here  because it was causing trouble, measure inference can now be turned back on. Stainless seems to have worked out the related problems.

Closes #86.